### PR TITLE
fix(billing): add MiniMax model prices and stop undercharging cache hits

### DIFF
--- a/crates/ocg-core/src/gateway/cost.rs
+++ b/crates/ocg-core/src/gateway/cost.rs
@@ -77,6 +77,30 @@ fn price_table_cell() -> &'static HashMap<String, ModelPrice> {
                 cache_read: 0.0145,
             },
         );
+        table.insert(
+            "minimax-m3".to_string(),
+            ModelPrice {
+                input: 3.15,
+                output: 12.60,
+                cache_read: 0.63,
+            },
+        );
+        table.insert(
+            "minimax-m2.7".to_string(),
+            ModelPrice {
+                input: 2.10,
+                output: 8.40,
+                cache_read: 0.42,
+            },
+        );
+        table.insert(
+            "minimax-m2.5".to_string(),
+            ModelPrice {
+                input: 2.10,
+                output: 8.40,
+                cache_read: 0.21,
+            },
+        );
         table
     })
 }
@@ -138,5 +162,32 @@ mod tests {
         let cost = cost_from_counts("glm-5.2", 100, 10, 80);
         let expected = (20.0 * 1.40 + 10.0 * 4.40 + 80.0 * 0.26) / 1_000_000.0;
         assert!((cost - expected).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn minimax_m3_uses_configured_price_table() {
+        let cost = cost_from_counts("minimax-m3", 1000, 200, 400);
+        let expected = (600.0 * 3.15 + 200.0 * 12.60 + 400.0 * 0.63) / 1_000_000.0;
+        assert!((cost - expected).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn minimax_m3_cache_read_is_not_free() {
+        // Regression: before the price table included minimax-m3, cache hits
+        // fell back to cache_read=0.0 and the request was heavily undercharged.
+        let cost = cost_from_counts("minimax-m3", 1000, 0, 1000);
+        let expected = 1000.0 * 0.63 / 1_000_000.0;
+        assert!((cost - expected).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn minimax_m2_uses_configured_price_table() {
+        let cost_m2_7 = cost_from_counts("minimax-m2.7", 1000, 200, 400);
+        let expected_m2_7 = (600.0 * 2.10 + 200.0 * 8.40 + 400.0 * 0.42) / 1_000_000.0;
+        assert!((cost_m2_7 - expected_m2_7).abs() < f64::EPSILON);
+
+        let cost_m2_5 = cost_from_counts("minimax-m2.5", 1000, 200, 400);
+        let expected_m2_5 = (600.0 * 2.10 + 200.0 * 8.40 + 400.0 * 0.21) / 1_000_000.0;
+        assert!((cost_m2_5 - expected_m2_5).abs() < f64::EPSILON);
     }
 }


### PR DESCRIPTION
## Problem

When using minimax-m3 through the Anthropic Messages upstream and calling it via OpenAI Chat Completions, OCG Manager was undercharging heavily (e.g. official deduction 0.0122 vs OCG log 0.00038) and the cache-hit portion appeared to dominate the input tokens.

## Root cause

minimax-m3, minimax-m2.7 and minimax-m2.5 were missing from the price table in crates/ocg-core/src/gateway/cost.rs. They fell back to the generic default price where cache_read = 0.0. For requests whose Anthropic usage reports large cache_read_input_tokens, almost the entire prompt cost was dropped, producing the observed low cost and a cache-hit ratio close to 100%.

The Anthropic  OpenAI token mapping (input_tokens + cache_read_input_tokens + cache_creation_input_tokens  prompt_tokens) is correct and already covered by tests; the issue was purely the missing model prices.

## Fix

Add price table entries for the MiniMax models using the official pay-as-you-go rates (512k tier for M3):

| Model | Input | Output | Cache read |
|---|---|---|---|
| minimax-m3 | 3.15 | 12.60 | 0.63 |
| minimax-m2.7 | 2.10 | 8.40 | 0.42 |
| minimax-m2.5 | 2.10 | 8.40 | 0.21 |

Also add unit tests covering the new entries and ensuring cache-read tokens are billed correctly.

## Verification

`ash
cargo test -p ocg-core cost::
`

All 158 tests in cargo test -p ocg-core pass.