### PR TITLE
fix: terminate stalled streams after idle timeout

### DIFF
--- a/crates/ocg-core/src/gateway/forwarder.rs
+++ b/crates/ocg-core/src/gateway/forwarder.rs
@@ -338,79 +338,88 @@ async fn forward_request_impl(
         let st_map = st.clone();
         let converter_map = converter.clone();
 
-        let mapped = stream.flat_map(move |result| {
-            let chunks = match result {
-                Ok(chunk) => {
-                    let stopped = {
-                        let state = st_map.lock();
-                        state.error || state.terminal
-                    } || converter_map.lock().is_terminal();
-                    if stopped {
-                        Vec::new()
-                    } else {
-                        process_chunk_for_usage(&mut st_map.lock(), upstream_format, &chunk);
-                        let converted = converter_map.lock().process_chunk(chunk);
-                        match converted {
-                            Ok(chunks) => chunks,
-                            Err(error) => {
-                                let msg = format!("stream conversion failed: {}", error.message);
-                                {
-                                    let mut state = st_map.lock();
-                                    state.error = true;
-                                    state.error_message = Some(msg.clone());
+        let mapped = stream
+            .flat_map(move |result| {
+                let (chunks, stop) = match result {
+                    Ok(chunk) => {
+                        let stopped = {
+                            let state = st_map.lock();
+                            state.error || state.terminal
+                        } || converter_map.lock().is_terminal();
+                        if stopped {
+                            (Vec::new(), true)
+                        } else {
+                            process_chunk_for_usage(&mut st_map.lock(), upstream_format, &chunk);
+                            let converted = converter_map.lock().process_chunk(chunk);
+                            match converted {
+                                Ok(chunks) => (chunks, false),
+                                Err(error) => {
+                                    let msg =
+                                        format!("stream conversion failed: {}", error.message);
+                                    {
+                                        let mut state = st_map.lock();
+                                        state.error = true;
+                                        state.error_message = Some(msg.clone());
+                                    }
+                                    let chunks = converter_map.lock().error_event(&msg);
+                                    let db = state_h.db.lock();
+                                    let _ = db.update_forward_log(
+                                        initial_id,
+                                        "error",
+                                        None,
+                                        ForwardMetrics::default(),
+                                        Some(&msg),
+                                    );
+                                    (chunks, true)
                                 }
-                                let chunks = converter_map.lock().error_event(&msg);
-                                let db = state_h.db.lock();
-                                let _ = db.update_forward_log(
-                                    initial_id,
-                                    "error",
-                                    None,
-                                    ForwardMetrics::default(),
-                                    Some(&msg),
-                                );
-                                chunks
                             }
                         }
                     }
-                }
-                Err(e) => {
-                    if converter_map.lock().is_terminal() {
-                        return futures_util::stream::iter(Vec::new());
+                    Err(e) => {
+                        if converter_map.lock().is_terminal() {
+                            (Vec::new(), true)
+                        } else {
+                            // Update the streaming row to "error" rather than inserting a new
+                            // row, then report the failure in the caller's SSE protocol.
+                            let msg = if e.is_timeout() {
+                                format!(
+                                    "stream error: upstream stream idle timeout after {}s",
+                                    stream_idle_timeout_secs
+                                )
+                            } else {
+                                format!("stream error: {e}")
+                            };
+                            {
+                                let mut state = st_map.lock();
+                                state.error = true;
+                                state.error_message = Some(msg.clone());
+                            }
+                            let chunks = converter_map.lock().error_event(&msg);
+                            let db = state_h.db.lock();
+                            let _ = db.update_forward_log(
+                                initial_id,
+                                "error",
+                                None,
+                                ForwardMetrics::default(),
+                                Some(&msg),
+                            );
+                            (chunks, true)
+                        }
                     }
-                    // Update the streaming row to "error" rather than inserting a new
-                    // row, then report the failure in the caller's SSE protocol.
-                    let msg = if e.is_timeout() {
-                        format!(
-                            "stream error: upstream stream idle timeout after {}s",
-                            stream_idle_timeout_secs
-                        )
-                    } else {
-                        format!("stream error: {e}")
-                    };
-                    {
-                        let mut state = st_map.lock();
-                        state.error = true;
-                        state.error_message = Some(msg.clone());
-                    }
-                    let chunks = converter_map.lock().error_event(&msg);
-                    let db = state_h.db.lock();
-                    let _ = db.update_forward_log(
-                        initial_id,
-                        "error",
-                        None,
-                        ForwardMetrics::default(),
-                        Some(&msg),
-                    );
-                    chunks
-                }
-            };
-            futures_util::stream::iter(
-                chunks
+                };
+                let mut items = chunks
                     .into_iter()
-                    .map(Ok::<bytes::Bytes, std::io::Error>)
-                    .collect::<Vec<_>>(),
-            )
-        });
+                    .map(|chunk| Some(Ok::<bytes::Bytes, std::io::Error>(chunk)))
+                    .collect::<Vec<_>>();
+                if stop {
+                    // The sentinel lets flat_map drain every generated error chunk, then
+                    // stops without polling the stalled upstream body for another item.
+                    items.push(None);
+                }
+                futures_util::stream::iter(items)
+            })
+            .take_while(|item| futures_util::future::ready(item.is_some()))
+            .map(|item| item.expect("stream stop sentinel should be filtered"));
 
         // Finalizer runs once, after the real stream is fully drained. It updates
         // the streaming row with final token counts and cost (or marks

--- a/crates/ocg-core/tests/gateway_fallback.rs
+++ b/crates/ocg-core/tests/gateway_fallback.rs
@@ -895,7 +895,9 @@ async fn stream_idle_timeout_emits_protocol_error_and_updates_log() {
         "text/event-stream",
         vec![
             (StdDuration::ZERO, MESSAGES_STREAM_HEAD),
-            (StdDuration::from_millis(1_200), MESSAGES_STREAM_TAIL),
+            // Keep the tail well beyond the configured idle timeout so a loaded
+            // Windows runner cannot race delivery against the timeout itself.
+            (StdDuration::from_secs(10), MESSAGES_STREAM_TAIL),
         ],
     )
     .await;
@@ -906,7 +908,7 @@ async fn stream_idle_timeout_emits_protocol_error_and_updates_log() {
     let (port, gateway_handle) = start_gateway(state.clone()).await;
 
     let (status, body) = tokio::time::timeout(
-        StdDuration::from_secs(4),
+        StdDuration::from_secs(8),
         protocol_stream_call(port, "/v1/messages", "minimax-m2.7"),
     )
     .await


### PR DESCRIPTION
## Summary

- emit every protocol-specific SSE error chunk after an upstream stream failure, then stop polling the stalled upstream body
- let the existing finalizer run immediately so the downstream response closes and the request log settles without waiting for another upstream chunk
- make the idle-timeout regression deterministic by placing the mock tail beyond the watchdog

## Context

The v1.4.1 release Windows job reproduced the same timeout twice. The gateway generated the idle-timeout error, but `flat_map` kept waiting for another upstream item before ending the response.

## Validation

- exact idle-timeout test: 25/25 sequential Windows stress runs (max 3.51s)
- `cargo test -p ocg-core --test gateway_fallback`: 21/21
- `cargo test -p ocg-core`: 166/166
- protocol-stream tests: 19/19
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- independent semantic review: Pass