### PR TITLE
docs: recognize Clement's contributions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,24 @@
+# Contributors / 贡献者
+
+OCG Manager is maintained by [Klarkxy](https://github.com/klarkxy) and
+improved by community contributions. Thank you to everyone who reports
+issues, proposes changes, reviews code, and helps validate releases.
+
+OCG Manager 由 [Klarkxy](https://github.com/klarkxy) 维护，也受益于社区的
+代码贡献、问题反馈、审查与发布验证。感谢每一位参与者。
+
+## Community contributors / 社区贡献者
+
+### [Clement (@moton16)](https://github.com/moton16)
+
+Contributed the following improvements released in OCG Manager v1.4.1:
+
+- [#10](https://github.com/klarkxy/opencode-go-mgr/pull/10): added current
+  MiniMax model pricing and corrected cache-hit cost calculations.
+- [#11](https://github.com/klarkxy/opencode-go-mgr/pull/11): added request-log
+  filtering by model and time, multi-field sorting, and top-level summaries.
+- [#12](https://github.com/klarkxy/opencode-go-mgr/pull/12): separated cooldown
+  windows and added reset countdowns to the account interface.
+
+为 OCG Manager v1.4.1 贡献了 MiniMax 模型计费补全、请求日志筛选与排序、
+独立冷却窗口及重置倒计时等改进。

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ mapped by the gateway. See the
 - [Maintainer guide](docs/MAINTAINER.md) · [维护者指南](docs/MAINTAINER.zh-CN.md)
 - [OpenCode‑Go anti‑abuse statement](OPENCODE_GO_ANTI_ABUSE.md) ·
   [OpenCode‑Go 防滥用声明](OPENCODE_GO_ANTI_ABUSE.zh-CN.md)
+- [Contributors / 贡献者](CONTRIBUTORS.md)
 
 ## Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -146,6 +146,7 @@ Claude Desktop 使用 `/claude-desktop/v1/messages`，把 Sonnet、Opus、Haiku
   [维护者指南](docs/MAINTAINER.zh-CN.md)
 - [OpenCode‑Go anti‑abuse statement](OPENCODE_GO_ANTI_ABUSE.md) ·
   [OpenCode‑Go 防滥用声明](OPENCODE_GO_ANTI_ABUSE.zh-CN.md)
+- [Contributors / 贡献者](CONTRIBUTORS.md)
 
 ## 开发模式
 


### PR DESCRIPTION
## Summary

- add a bilingual `CONTRIBUTORS.md`
- credit Clement (`@moton16`) for PRs #10, #11, and #12
- link the contributor document from both READMEs

## Why

The original PR commits used bot or maintainer author identities, so GitHub
did not associate the merged work with `@moton16`. This non-empty documentation
commit uses Clement's GitHub-linked email as Author while retaining the
maintainer as Committer.

## Validation

- `git diff --check`
- README link targets exist
- GitHub Commit API reports `authorLogin=moton16` and
  `committerLogin=klarkxy` for `e3337602`
