### PR TITLE
fix(ci): handle empty Windows startup registry key

### DIFF
--- a/scripts/generate-updater-manifest.test.mjs
+++ b/scripts/generate-updater-manifest.test.mjs
@@ -183,7 +183,11 @@ test("Windows release smoke waits only for bounded installer processes", () => {
   assert.doesNotMatch(smoke, /Start-Process \$CandidateInstaller[^\r\n]*-Wait/);
   assert.doesNotMatch(smoke, /Start-Process \$PreviousInstaller[^\r\n]*-Wait/);
   assert.match(smoke, /Wait-UninstallComplete/);
-  assert.match(smoke, /Get-ItemProperty -LiteralPath \$RunKey -ErrorAction SilentlyContinue/);
+  assert.match(smoke, /function Test-RegistryValue/);
+  assert.match(smoke, /Get-Item[^\r\n]*-ErrorAction Stop/);
+  assert.match(smoke, /catch \[System\.Management\.Automation\.ItemNotFoundException\]/);
+  assert.match(smoke, /\.GetValueNames\(\)/);
+  assert.doesNotMatch(smoke, /\.PSObject\.Properties\.Name/);
   assert.match(smoke, /-RunKey \$runKey/);
   assert.match(workflow, /\$env:USERPROFILE/);
   assert.doesNotMatch(smoke, /\$env:USERPROFILE\s*=/);

--- a/scripts/smoke-windows-release.ps1
+++ b/scripts/smoke-windows-release.ps1
@@ -82,6 +82,19 @@ function Invoke-Installer {
   Write-Host "Completed $Label"
 }
 
+function Test-RegistryValue {
+  param(
+    [string]$Path,
+    [string]$Name
+  )
+  try {
+    $key = Get-Item -LiteralPath $Path -ErrorAction Stop
+  } catch [System.Management.Automation.ItemNotFoundException] {
+    return $false
+  }
+  return [bool]($key -and ($key.GetValueNames() -contains $Name))
+}
+
 function Wait-UninstallComplete {
   param(
     [string]$ExecutablePath,
@@ -90,10 +103,7 @@ function Wait-UninstallComplete {
     [int]$Attempts = 90
   )
   foreach ($attempt in 1..$Attempts) {
-    $runValues = Get-ItemProperty -LiteralPath $RunKey -ErrorAction SilentlyContinue
-    $startupEntryPresent = $runValues -and (
-      $runValues.PSObject.Properties.Name -contains 'OCG Manager'
-    )
+    $startupEntryPresent = Test-RegistryValue -Path $RunKey -Name 'OCG Manager'
     if (
       !(Test-Path -LiteralPath $ExecutablePath) -and
       !(Test-Path -LiteralPath $UninstallerPath) -and
@@ -177,7 +187,7 @@ try {
 
   $settings.auto_start = $false
   Invoke-RestMethod $settingsUrl -Method Post -ContentType 'application/json' -Body ($settings | ConvertTo-Json) | Out-Null
-  if ((Get-ItemProperty -LiteralPath $runKey).PSObject.Properties.Name -contains 'OCG Manager') {
+  if (Test-RegistryValue -Path $runKey -Name 'OCG Manager') {
     throw 'Disabling auto-start left the startup entry behind'
   }
   $settings.auto_start = $true
@@ -196,7 +206,7 @@ $uninstaller = Get-ChildItem $installDir -Recurse -Filter uninstall.exe | Select
 if (!$uninstaller) { throw 'Uninstaller is missing' }
 Invoke-Installer -Path $uninstaller.FullName -Arguments @('/S') -Label 'candidate uninstall'
 Wait-UninstallComplete -ExecutablePath $guiPath -UninstallerPath $uninstaller.FullName -RunKey $runKey
-if ((Get-ItemProperty -LiteralPath $runKey).PSObject.Properties.Name -contains 'OCG Manager') {
+if (Test-RegistryValue -Path $runKey -Name 'OCG Manager') {
   throw 'Uninstall left the startup entry behind'
 }
 if (!(Test-Path $sentinel)) { throw 'Silent uninstall deleted user data' }

--- a/scripts/validate-windows-release-smoke.ps1
+++ b/scripts/validate-windows-release-smoke.ps1
@@ -13,7 +13,7 @@ $script = Get-Content -LiteralPath $resolvedScript -Raw
 
 $tokens = $null
 $errors = $null
-[void][System.Management.Automation.Language.Parser]::ParseFile(
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
   $resolvedScript,
   [ref]$tokens,
   [ref]$errors
@@ -34,6 +34,7 @@ if ($workflow -match 'function\s+Invoke-Installer') {
 foreach ($requiredPattern in @(
   '\.WaitForExit\(1000 \* \$TimeoutSeconds\)',
   '\.Kill\(\$true\)',
+  'Test-RegistryValue',
   'Wait-UninstallComplete',
   'Overwrite update did not preserve the auto-start setting'
 )) {
@@ -41,6 +42,59 @@ foreach ($requiredPattern in @(
     throw "Windows release smoke is missing required behavior: $requiredPattern"
   }
 }
+if ($script -match '\.PSObject\.Properties\.Name') {
+  throw 'Windows release smoke must handle an empty registry value collection under StrictMode'
+}
+$registryHelper = $ast.Find({
+  param($node)
+  $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+    $node.Name -eq 'Test-RegistryValue'
+}, $true)
+if (!$registryHelper) {
+  throw 'Windows release smoke is missing Test-RegistryValue'
+}
+& {
+  param([string]$Definition)
+  Invoke-Expression $Definition
+
+  function Get-Item {
+    [CmdletBinding()]
+    param([string]$LiteralPath)
+    if ($script:registryProbeMode -eq 'missing') {
+      throw [System.Management.Automation.ItemNotFoundException]::new('missing registry key')
+    }
+    if ($script:registryProbeMode -eq 'denied') {
+      throw [System.Security.SecurityException]::new('registry access denied')
+    }
+    $key = [pscustomobject]@{ ValueNames = @($script:registryProbeValues) }
+    $key | Add-Member -MemberType ScriptMethod -Name GetValueNames -Value { @($this.ValueNames) }
+    return $key
+  }
+
+  $script:registryProbeMode = 'present'
+  $script:registryProbeValues = @()
+  if (Test-RegistryValue -Path 'mock:' -Name 'OCG Manager') {
+    throw 'An empty registry key was reported as containing the startup value'
+  }
+  $script:registryProbeValues = @('OCG Manager')
+  if (!(Test-RegistryValue -Path 'mock:' -Name 'OCG Manager')) {
+    throw 'The startup registry value was not detected'
+  }
+  $script:registryProbeMode = 'missing'
+  if (Test-RegistryValue -Path 'mock:' -Name 'OCG Manager') {
+    throw 'A missing registry key was reported as containing the startup value'
+  }
+  $script:registryProbeMode = 'denied'
+  $accessDenied = $false
+  try {
+    Test-RegistryValue -Path 'mock:' -Name 'OCG Manager' | Out-Null
+  } catch [System.Security.SecurityException] {
+    $accessDenied = $true
+  }
+  if (!$accessDenied) {
+    throw 'Registry access errors must fail the Windows release smoke'
+  }
+} $registryHelper.Extent.Text
 if ($workflow -notmatch '\$env:USERPROFILE') {
   throw 'Release workflow must pass the real runner profile data directory'
 }


### PR DESCRIPTION
Fixes the v1.5.0 Windows release candidate failure after auto-start is disabled. The smoke test now treats only a missing registry key as absent, propagates access errors, and runs the real helper against empty, present, missing, and denied mock cases. Validation: PowerShell release-smoke validator; release helper tests 24/24; pnpm run test:web 98/98; git diff --check. Independent re-review passed.