### PR TITLE
fix(ci): verify draft releases by id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,6 +374,8 @@ jobs:
       - quality
       - build
     runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
     permissions:
       contents: write
 
@@ -410,6 +412,7 @@ jobs:
           overwrite: true
 
       - name: Create or update draft release
+        id: release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -426,6 +429,19 @@ jobs:
           else
             gh release create "$GITHUB_REF_NAME" release/* --draft --verify-tag --title "OCG Manager $GITHUB_REF_NAME" --notes "$notes"
           fi
+          release_metadata=$(gh release view "$GITHUB_REF_NAME" --json databaseId,isDraft,tagName)
+          if ! jq -e --arg tag "$GITHUB_REF_NAME" \
+            '.isDraft == true and .tagName == $tag and (.databaseId | type == "number")' \
+            <<<"$release_metadata" >/dev/null; then
+            echo "Refusing to continue without the exact draft Release identity." >&2
+            exit 1
+          fi
+          release_id=$(jq -r .databaseId <<<"$release_metadata")
+          if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
+            echo "Invalid draft Release id: $release_id" >&2
+            exit 1
+          fi
+          echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
 
   verify-release:
     name: Verify draft release
@@ -436,6 +452,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       asset_digest: ${{ steps.asset_metadata.outputs.digest }}
+      release_id: ${{ steps.asset_metadata.outputs.release_id }}
     permissions:
       contents: read
 
@@ -458,15 +475,25 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.draft-release.outputs.release_id }}
         run: |
           set -euo pipefail
+          if [[ ! "$RELEASE_ID" =~ ^[0-9]+$ ]]; then
+            echo "Invalid draft Release id: $RELEASE_ID" >&2
+            exit 1
+          fi
           ready=false
           for attempt in 1 2 3 4 5; do
-            gh api "repos/$GITHUB_REPOSITORY/releases/tags/$GITHUB_REF_NAME" \
-              --jq '[.assets[] | {name, digest}]' > asset-metadata.json
-            if jq -e 'length == 15 and all(.[]; .digest | type == "string")' asset-metadata.json >/dev/null; then
-              ready=true
-              break
+            if gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > release-metadata.json; then
+              if jq -e --argjson release_id "$RELEASE_ID" --arg tag "$GITHUB_REF_NAME" \
+                '.id == $release_id and .tag_name == $tag and .draft == true
+                  and (.assets | length == 15)
+                  and all(.assets[]; (.name | type == "string") and (.digest | type == "string"))' \
+                release-metadata.json >/dev/null; then
+                jq '[.assets[] | {name, digest}]' release-metadata.json > asset-metadata.json
+                ready=true
+                break
+              fi
             fi
             sleep 3
           done
@@ -476,6 +503,7 @@ jobs:
           fi
           digest=$(jq -S -c 'sort_by(.name)' asset-metadata.json | sha256sum | cut -d' ' -f1)
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
 
       - name: Verify checksums, updater manifest, signatures, and server digests
         env:
@@ -510,21 +538,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          RELEASE_ID: ${{ needs.verify-release.outputs.release_id }}
           VERIFIED_ASSET_DIGEST: ${{ needs.verify-release.outputs.asset_digest }}
         run: |
           set -euo pipefail
-          state=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$GITHUB_REF_NAME" --jq .draft)
-          if [ "$state" != true ]; then
-            echo "Refusing to publish a release that is not the verified draft." >&2
-            exit 1
-          fi
-          current_asset_digest=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$GITHUB_REF_NAME" \
-            --jq '[.assets[] | {name, digest}]' \
-            | jq -S -c 'sort_by(.name)' \
-            | sha256sum \
-            | cut -d' ' -f1)
-          if [ "$current_asset_digest" != "$VERIFIED_ASSET_DIGEST" ]; then
-            echo "Refusing to publish: draft assets changed after verification." >&2
+          if [[ ! "$RELEASE_ID" =~ ^[0-9]+$ ]]; then
+            echo "Invalid verified Release id: $RELEASE_ID" >&2
             exit 1
           fi
           latest_error="$RUNNER_TEMP/latest-release-error"
@@ -539,8 +558,23 @@ jobs:
           make_latest=$(node scripts/release-policy.mjs should-advance \
             --candidate "$GITHUB_REF_NAME" \
             --current "$current_latest")
-          release_id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$GITHUB_REF_NAME" --jq .id)
-          gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$release_id" \
+          gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" > release-metadata.json
+          if ! jq -e --argjson release_id "$RELEASE_ID" --arg tag "$GITHUB_REF_NAME" \
+            '.id == $release_id and .tag_name == $tag and .draft == true
+              and (.assets | length == 15)
+              and all(.assets[]; (.name | type == "string") and (.digest | type == "string"))' \
+            release-metadata.json >/dev/null; then
+            echo "Refusing to publish a Release that is not the exact verified draft." >&2
+            exit 1
+          fi
+          current_asset_digest=$(jq -S -c '[.assets[] | {name, digest}] | sort_by(.name)' release-metadata.json \
+            | sha256sum \
+            | cut -d' ' -f1)
+          if [ "$current_asset_digest" != "$VERIFIED_ASSET_DIGEST" ]; then
+            echo "Refusing to publish: draft assets changed after verification." >&2
+            exit 1
+          fi
+          gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
             -F draft=false \
             -f make_latest="$make_latest" \
             --silent

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -442,7 +442,10 @@ manifest, signatures, and every other attachment, and creates or updates a
 **draft** GitHub Release. `verify-release` then requires the exact 15-asset
 set, re-derives `latest.json`, recomputes every checksum, verifies all four
 updater signatures, and compares every downloaded artifact with the digest
-reported by GitHub Release storage.
+reported by GitHub Release storage. The draft job passes its numeric Release
+ID downstream; verification and publication re-check that exact ID, tag, and
+draft state instead of using the tag lookup endpoint, which does not expose
+draft Releases.
 
 ### publish-release — publish only the verified tag build
 

--- a/docs/MAINTAINER.zh-CN.md
+++ b/docs/MAINTAINER.zh-CN.md
@@ -370,7 +370,9 @@ artifact，把平台 payload、签名与 `compose.example.yaml` 组装进 `relea
 manifest、签名和其余附件的 `SHA256SUMS`，最后创建或更新 **draft** GitHub
 Release。`verify-release` 随后要求资产集合恰好为 15 个，重新推导
 `latest.json`、重算全部 checksum、验证四份升级签名，并把每个下载文件与
-GitHub Release 存储层报告的 digest 对比。
+GitHub Release 存储层报告的 digest 对比。draft job 会把数字 Release ID 传给下
+游；验证和公开 job 都重新校验该 ID、tag 与 draft 状态，不使用无法显示 draft
+Release 的 tag 查询端点。
 
 ### publish-release —— 只公开已验证的 tag 构建
 

--- a/scripts/release-policy.test.mjs
+++ b/scripts/release-policy.test.mjs
@@ -92,6 +92,30 @@ test("manual release runs cannot inherit the production tag path", () => {
   assert.doesNotMatch(publishJob, /environment:|always\(\)/);
 });
 
+test("the exact draft Release identity flows through verification and publication", () => {
+  const workflow = readFileSync(
+    new URL("../.github/workflows/release.yml", import.meta.url),
+    "utf8",
+  );
+  const draftJob = workflow.match(/\n  draft-release:[\s\S]*?\n  verify-release:/)?.[0] ?? "";
+  const verifyJob = workflow.match(/\n  verify-release:[\s\S]*?\n  publish-release:/)?.[0] ?? "";
+  const publishJob = workflow.match(/\n  publish-release:[\s\S]*$/)?.[0] ?? "";
+
+  assert.match(draftJob, /release_id: \$\{\{ steps\.release\.outputs\.release_id \}\}/);
+  assert.match(draftJob, /- name: Create or update draft release\s+id: release/);
+  assert.match(draftJob, /gh release view "\$GITHUB_REF_NAME" --json databaseId,isDraft,tagName/);
+  assert.match(verifyJob, /release_id: \$\{\{ steps\.asset_metadata\.outputs\.release_id \}\}/);
+  assert.match(verifyJob, /RELEASE_ID: \$\{\{ needs\.draft-release\.outputs\.release_id \}\}/);
+  assert.match(verifyJob, /if gh api "repos\/\$GITHUB_REPOSITORY\/releases\/\$RELEASE_ID"/);
+  assert.match(verifyJob, /\.id == \$release_id and \.tag_name == \$tag and \.draft == true/);
+  assert.match(verifyJob, /\.assets \| length == 15/);
+  assert.doesNotMatch(verifyJob, /releases\/tags\//);
+  assert.match(publishJob, /RELEASE_ID: \$\{\{ needs\.verify-release\.outputs\.release_id \}\}/);
+  assert.match(publishJob, /gh api "repos\/\$GITHUB_REPOSITORY\/releases\/\$RELEASE_ID" > release-metadata\.json/);
+  assert.match(publishJob, /--method PATCH "repos\/\$GITHUB_REPOSITORY\/releases\/\$RELEASE_ID"/);
+  assert.doesNotMatch(publishJob, /releases\/tags\//);
+});
+
 test("container publication checks out an exact tag and validates source versions", () => {
   const workflow = readFileSync(
     new URL("../.github/workflows/container.yml", import.meta.url),


### PR DESCRIPTION
## What changed

- pass the numeric draft GitHub Release ID from creation through verification and publication
- verify the exact ID, tag, draft state, 15 assets, and server digests before publishing
- make metadata retries effective under `set -e`
- remove draft lookups through `/releases/tags/{tag}`, which returns 404 for draft Releases
- keep the existing updater signature, checksum, asset fingerprint, and monotonic latest checks

## Root cause

The v1.5.0 production run created all 15 signed assets successfully, but `verify-release` queried the draft through the tag REST endpoint. GitHub returned 404 for that draft even though the numeric Release endpoint exposed it. Because the command ran under `set -e`, the intended retry loop also exited on its first request.

## Validation

- release helper and policy tests: 25/25
- `pnpm run release:check`
- `git diff --check`
- independent read-only review: Pass, no blocker

The existing v1.5.0 tag and draft assets are not changed by this PR.
