### PR TITLE
fix: harden PR #22 follow-up

### DIFF
--- a/crates/ocg-core/src/dashboard.rs
+++ b/crates/ocg-core/src/dashboard.rs
@@ -1008,9 +1008,7 @@ async fn update_account_usage(
     let percent = (update.percent * 10.0).round() / 10.0;
     if let Some(mins) = update.resets_in_minutes {
         if mins < 0 {
-            return Err(ApiError::bad_request(
-                "resets_in_minutes must be >= 0",
-            ));
+            return Err(ApiError::bad_request("resets_in_minutes must be >= 0"));
         }
     }
 
@@ -2348,7 +2346,10 @@ mod tests {
             .resets_in_month
             .expect("month reset should be set after calibrate");
         assert_eq!(
-            reset.with_timezone(&chrono::Local).format("%Y-%m-%d").to_string(),
+            reset
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d")
+                .to_string(),
             "2026-02-28"
         );
         let summary = dashboard_summary(State(state))

--- a/crates/ocg-core/src/db.rs
+++ b/crates/ocg-core/src/db.rs
@@ -102,6 +102,119 @@ fn ensure_column(
     Ok(())
 }
 
+fn migrate_legacy_usage_baselines(
+    tx: &rusqlite::Transaction<'_>,
+    limits: &PricingLimits,
+    now: DateTime<Utc>,
+) -> Result<()> {
+    type LegacyUsageRow = (
+        String,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        String,
+    );
+
+    let accounts = {
+        let mut stmt = tx.prepare(
+            "SELECT id,
+                    usage_5h_baseline_percent, usage_5h_anchor_success_cost,
+                    usage_week_baseline_percent, usage_week_anchor_success_cost,
+                    usage_month_baseline_percent, usage_month_anchor_success_cost,
+                    recharge_date
+             FROM accounts
+             WHERE usage_5h_baseline_percent IS NOT NULL
+                OR usage_week_baseline_percent IS NOT NULL
+                OR usage_month_baseline_percent IS NOT NULL",
+        )?;
+        stmt.query_map([], |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
+                row.get(7)?,
+            ))
+        })?
+        .collect::<rusqlite::Result<Vec<LegacyUsageRow>>>()?
+    };
+    let now_string = now.to_rfc3339();
+
+    for (
+        id,
+        percent_5h,
+        anchor_5h,
+        percent_week,
+        anchor_week,
+        percent_month,
+        anchor_month,
+        purchase_date,
+    ) in accounts
+    {
+        let total_cost: f64 = tx.query_row(
+            "SELECT COALESCE(SUM(cost), 0) FROM forward_logs
+             WHERE account_id = ?1
+               AND cost_state IN ('priced', 'legacy_estimate')",
+            [&id],
+            |row| row.get(0),
+        )?;
+        let migrated_5h = percent_5h
+            .zip(anchor_5h)
+            .map(|baseline| effective_usage(0.0, Some(baseline), total_cost, limits.window_5h));
+        let migrated_week = percent_week
+            .zip(anchor_week)
+            .map(|baseline| effective_usage(0.0, Some(baseline), total_cost, limits.window_week));
+        let migrated_month = match percent_month.zip(anchor_month) {
+            Some(baseline) => {
+                let month_start = month_window_start_utc(&purchase_date)?.to_rfc3339();
+                let actual_month_cost: f64 = tx.query_row(
+                    "SELECT COALESCE(SUM(cost), 0) FROM forward_logs
+                     WHERE account_id = ?1
+                       AND cost_state IN ('priced', 'legacy_estimate')
+                       AND timestamp >= ?2",
+                    params![&id, month_start],
+                    |row| row.get(0),
+                )?;
+                Some(
+                    effective_usage(0.0, Some(baseline), total_cost, limits.window_month)
+                        - actual_month_cost,
+                )
+            }
+            None => None,
+        };
+
+        tx.execute(
+            "UPDATE accounts SET
+                usage_5h_window_started_at = CASE WHEN ?2 IS NULL THEN usage_5h_window_started_at ELSE ?1 END,
+                usage_5h_window_cost_offset = COALESCE(?2, usage_5h_window_cost_offset),
+                usage_week_window_started_at = CASE WHEN ?3 IS NULL THEN usage_week_window_started_at ELSE ?1 END,
+                usage_week_window_cost_offset = COALESCE(?3, usage_week_window_cost_offset),
+                usage_month_window_cost_offset = COALESCE(?4, usage_month_window_cost_offset),
+                usage_5h_baseline_percent = NULL,
+                usage_5h_anchor_success_cost = NULL,
+                usage_week_baseline_percent = NULL,
+                usage_week_anchor_success_cost = NULL,
+                usage_month_baseline_percent = NULL,
+                usage_month_anchor_success_cost = NULL
+             WHERE id = ?5",
+            params![
+                &now_string,
+                migrated_5h,
+                migrated_week,
+                migrated_month,
+                &id
+            ],
+        )?;
+    }
+    Ok(())
+}
+
 impl Database {
     pub fn open(data_dir: PathBuf) -> Result<Self> {
         std::fs::create_dir_all(&data_dir)?;
@@ -532,6 +645,30 @@ impl Database {
             }
             tx.execute(
                 "INSERT OR REPLACE INTO schema_version (version) VALUES (12)",
+                [],
+            )?;
+        }
+
+        if version < 13 {
+            // v13 preserves manual calibrations from the old rolling-window
+            // baseline model. Anchor fixed windows at the migration instant so
+            // already-counted logs are not charged twice, then let new logs
+            // accumulate normally from that point onward.
+            let limits = tx
+                .query_row(
+                    "SELECT snapshot_json FROM pricing_snapshots
+                     ORDER BY activated_at DESC LIMIT 1",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+                .map(|json| serde_json::from_str::<PricingSnapshot>(&json))
+                .transpose()?
+                .map(|snapshot| snapshot.limits)
+                .unwrap_or_else(|| crate::pricing::embedded_seed().limits);
+            migrate_legacy_usage_baselines(&tx, &limits, Utc::now())?;
+            tx.execute(
+                "INSERT OR REPLACE INTO schema_version (version) VALUES (13)",
                 [],
             )?;
         }
@@ -1095,27 +1232,40 @@ impl Database {
         let now = Utc::now();
         // (started_at, offset_col, started_col_or_empty)
         // started_col 为空字符串表示月窗口——不写 started_at 列（起点固定为 purchase_date）。
-        let (started_at, started_col, offset_col): (Option<DateTime<Utc>>, &str, &str) = match window {
-            UsageWindowKind::FiveHours => {
-                let window_len = Duration::hours(5);
-                let ends_at = now
-                    + Duration::minutes(resets_in_minutes.unwrap_or_else(|| window_len.num_minutes()));
-                let started_at = ends_at - window_len;
-                (Some(started_at), "usage_5h_window_started_at", "usage_5h_window_cost_offset")
-            }
-            UsageWindowKind::Week => {
-                let window_len = Duration::days(7);
-                let ends_at = now
-                    + Duration::minutes(resets_in_minutes.unwrap_or_else(|| window_len.num_minutes()));
-                let started_at = ends_at - window_len;
-                (Some(started_at), "usage_week_window_started_at", "usage_week_window_cost_offset")
-            }
-            UsageWindowKind::Month => {
-                // 月窗口的起点/终点由 purchase_date 决定，不写 started_at 列。
-                // resets_in_minutes 被忽略——窗口已由账号购买日期固定。
-                (None, "", "usage_month_window_cost_offset")
-            }
-        };
+        let (started_at, started_col, offset_col): (Option<DateTime<Utc>>, &str, &str) =
+            match window {
+                UsageWindowKind::FiveHours => {
+                    let window_len = Duration::hours(5);
+                    let ends_at = now
+                        + Duration::minutes(
+                            resets_in_minutes.unwrap_or_else(|| window_len.num_minutes()),
+                        );
+                    let started_at = ends_at - window_len;
+                    (
+                        Some(started_at),
+                        "usage_5h_window_started_at",
+                        "usage_5h_window_cost_offset",
+                    )
+                }
+                UsageWindowKind::Week => {
+                    let window_len = Duration::days(7);
+                    let ends_at = now
+                        + Duration::minutes(
+                            resets_in_minutes.unwrap_or_else(|| window_len.num_minutes()),
+                        );
+                    let started_at = ends_at - window_len;
+                    (
+                        Some(started_at),
+                        "usage_week_window_started_at",
+                        "usage_week_window_cost_offset",
+                    )
+                }
+                UsageWindowKind::Month => {
+                    // 月窗口的起点/终点由 purchase_date 决定，不写 started_at 列。
+                    // resets_in_minutes 被忽略——窗口已由账号购买日期固定。
+                    (None, "", "usage_month_window_cost_offset")
+                }
+            };
 
         // 计算 actual_cost：窗口内已有 forward_logs 的 cost 总和。
         // 5h/周窗口的起点是刚算出的 started_at；月窗口的起点是 purchase_date 00:00 本地时区。
@@ -1226,7 +1376,7 @@ impl Database {
                         resets_in_5h: None,
                         resets_in_week: None,
                         resets_in_month: None,
-                    })
+                    });
                 }
             };
 
@@ -1235,22 +1385,26 @@ impl Database {
             account_id,
             started_5h_str.as_deref(),
             offset_5h,
-            Duration::hours(5),
             limits.window_5h,
             now,
-            "usage_5h_window_started_at",
-            "usage_5h_window_cost_offset",
+            FixedWindowSpec {
+                length: Duration::hours(5),
+                started_col: "usage_5h_window_started_at",
+                offset_col: "usage_5h_window_cost_offset",
+            },
         )?;
         let (cost_week, reset_week) = compute_fixed_window(
             &self.conn,
             account_id,
             started_week_str.as_deref(),
             offset_week,
-            Duration::days(7),
             limits.window_week,
             now,
-            "usage_week_window_started_at",
-            "usage_week_window_cost_offset",
+            FixedWindowSpec {
+                length: Duration::days(7),
+                started_col: "usage_week_window_started_at",
+                offset_col: "usage_week_window_cost_offset",
+            },
         )?;
         let (cost_month, reset_month) = compute_month_window(
             &self.conn,
@@ -1334,16 +1488,20 @@ impl Database {
 
 /// 计算固定窗口的当前用量与清零时刻。`started_at_str` 为 `None` 表示账号从未使用过该窗口；
 /// 窗口已过期时从 `forward_logs` lazy 重建新起点。
+struct FixedWindowSpec {
+    length: Duration,
+    started_col: &'static str,
+    offset_col: &'static str,
+}
+
 fn compute_fixed_window(
     conn: &Connection,
     account_id: &str,
     started_at_str: Option<&str>,
     offset: f64,
-    window_len: Duration,
     limit: f64,
     now: DateTime<Utc>,
-    started_col: &str,
-    offset_col: &str,
+    spec: FixedWindowSpec,
 ) -> Result<(f64, Option<DateTime<Utc>>)> {
     let mut started_at = match started_at_str {
         None => {
@@ -1365,8 +1523,9 @@ fn compute_fixed_window(
                 Some(s) => {
                     conn.execute(
                         &format!(
-                            "UPDATE accounts SET {started_col} = ?2, {offset_col} = 0
-                             WHERE id = ?1"
+                            "UPDATE accounts SET {} = ?2, {} = 0
+                             WHERE id = ?1",
+                            spec.started_col, spec.offset_col
                         ),
                         params![account_id, &s],
                     )?;
@@ -1381,7 +1540,7 @@ fn compute_fixed_window(
     let mut effective_offset = offset;
 
     loop {
-        let ends_at = started_at + window_len;
+        let ends_at = started_at + spec.length;
         if now < ends_at {
             // 窗口仍有效：用量 = effective_offset + SUM(cost WHERE ts >= started_at)
             let cost: f64 = conn.query_row(
@@ -1395,7 +1554,7 @@ fn compute_fixed_window(
             return Ok(((effective_offset + cost).min(limit), Some(ends_at)));
         }
 
-        // 窗口已过期：找 forward_logs 中第一条 timestamp > ends_at 的计费请求作为新起点。
+        // 窗口已过期：找 forward_logs 中第一条 timestamp >= ends_at 的计费请求作为新起点。
         // 关键修复：旧实现只前进一次就 return，遇到多条稀疏日志（间隔 > 5h）时每次刷新
         // 只前进一个窗口，造成前端可见的"用量从 60 → 30 → 13 → 5.8 → 0"递减幻觉；
         // 当 next=None 清空后下次刷新又 lazy-init 回最旧日志，循环重启。
@@ -1405,7 +1564,7 @@ fn compute_fixed_window(
                 "SELECT MIN(timestamp) FROM forward_logs
                  WHERE account_id = ?1
                    AND cost_state IN ('priced', 'legacy_estimate')
-                   AND timestamp > ?2",
+                   AND timestamp >= ?2",
                 params![account_id, ends_at.to_rfc3339()],
                 |row| row.get(0),
             )
@@ -1416,8 +1575,9 @@ fn compute_fixed_window(
                 // 过期后无新请求：清空窗口，等待下次请求触发新窗口。
                 conn.execute(
                     &format!(
-                        "UPDATE accounts SET {started_col} = NULL, {offset_col} = 0
-                         WHERE id = ?1"
+                        "UPDATE accounts SET {} = NULL, {} = 0
+                         WHERE id = ?1",
+                        spec.started_col, spec.offset_col
                     ),
                     [account_id],
                 )?;
@@ -1428,8 +1588,9 @@ fn compute_fixed_window(
                 effective_offset = 0.0;
                 conn.execute(
                     &format!(
-                        "UPDATE accounts SET {started_col} = ?2, {offset_col} = 0
-                         WHERE id = ?1"
+                        "UPDATE accounts SET {} = ?2, {} = 0
+                         WHERE id = ?1",
+                        spec.started_col, spec.offset_col
                     ),
                     params![account_id, &s],
                 )?;
@@ -1490,12 +1651,11 @@ fn month_window_start_utc(purchase_date: &str) -> Result<DateTime<Utc>> {
 }
 
 fn parse_rfc3339(s: &str) -> Result<DateTime<Utc>> {
-    Ok(DateTime::parse_from_rfc3339(s)
+    DateTime::parse_from_rfc3339(s)
         .map(|dt| dt.with_timezone(&Utc))
-        .map_err(|e| anyhow::anyhow!("invalid RFC3339 timestamp: {e}"))?)
+        .map_err(|e| anyhow::anyhow!("invalid RFC3339 timestamp: {e}"))
 }
 
-#[allow(dead_code)]
 fn effective_usage(
     local_window_cost: f64,
     baseline: Option<(f64, f64)>,
@@ -1845,7 +2005,7 @@ mod tests {
                     row.get(0)
                 })
                 .expect("schema version should load");
-            assert_eq!(version, 12, "{label}");
+            assert_eq!(version, 13, "{label}");
             let account = db
                 .get_account("old")
                 .expect("account query should work")
@@ -1923,7 +2083,7 @@ mod tests {
             })
             .expect("schema version should be readable");
         let usage = db.account_usage("old").expect("usage should load");
-        assert_eq!(version, 12);
+        assert_eq!(version, 13);
         assert_eq!(
             db.get_account("old")
                 .expect("account should load")
@@ -2072,7 +2232,7 @@ mod tests {
                 row.get(0)
             })
             .expect("schema version should load");
-        assert_eq!(version, 12);
+        assert_eq!(version, 13);
         assert_eq!(
             db.get_account("valid")
                 .expect("valid account query should work")
@@ -2216,7 +2376,7 @@ mod tests {
                 row.get(0)
             })
             .expect("schema version should load");
-        assert_eq!(version, 12);
+        assert_eq!(version, 13);
         let states = db
             .conn
             .prepare("SELECT cost, cost_state FROM forward_logs ORDER BY id")
@@ -2265,7 +2425,7 @@ mod tests {
                 row.get(0)
             })
             .expect("schema version should load");
-        assert_eq!(version, 12);
+        assert_eq!(version, 13);
 
         let created_at = DateTime::parse_from_rfc3339("2026-01-02T01:30:00+02:00")
             .expect("fixed timestamp should parse")
@@ -2561,6 +2721,75 @@ mod tests {
     }
 
     #[test]
+    fn v13_migration_preserves_legacy_manual_usage_calibration() {
+        let dir = temp_data_dir("v13-legacy-calibration");
+        let db = Database::open(dir.clone()).expect("db should open");
+        let mut acct = account("legacy-calibration");
+        acct.purchase_date = local_today();
+        db.create_account(&acct).expect("account should be created");
+        finalize_success(&db, "legacy-calibration", 2.0, Utc::now());
+        db.conn
+            .execute(
+                "UPDATE accounts SET
+                    usage_5h_baseline_percent = 50,
+                    usage_5h_anchor_success_cost = 2,
+                    usage_week_baseline_percent = 40,
+                    usage_week_anchor_success_cost = 2,
+                    usage_month_baseline_percent = 25,
+                    usage_month_anchor_success_cost = 2
+                 WHERE id = 'legacy-calibration'",
+                [],
+            )
+            .expect("legacy baselines should save");
+        finalize_success(&db, "legacy-calibration", 1.0, Utc::now());
+        db.conn
+            .execute_batch(
+                "DELETE FROM schema_version;
+                 INSERT INTO schema_version (version) VALUES (10);",
+            )
+            .expect("legacy schema version should save");
+        drop(db);
+
+        let db = Database::open(dir.clone()).expect("legacy database should migrate");
+        let usage = db
+            .account_usage("legacy-calibration")
+            .expect("migrated usage should load");
+        // Old effective values: 50% * 12 + 1, 40% * 30 + 1,
+        // and 25% * 60 + 1. The migration must preserve all three.
+        assert_cost(usage.window_5h, 7.0);
+        assert_cost(usage.window_week, 13.0);
+        assert_cost(usage.window_month, 16.0);
+
+        let (version, remaining_baselines): (i32, i64) = db
+            .conn
+            .query_row(
+                "SELECT
+                    (SELECT MAX(version) FROM schema_version),
+                    COUNT(*)
+                 FROM accounts
+                 WHERE usage_5h_baseline_percent IS NOT NULL
+                    OR usage_week_baseline_percent IS NOT NULL
+                    OR usage_month_baseline_percent IS NOT NULL",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("migration state should load");
+        assert_eq!(version, 13);
+        assert_eq!(remaining_baselines, 0);
+
+        finalize_success(&db, "legacy-calibration", 2.0, Utc::now());
+        let usage = db
+            .account_usage("legacy-calibration")
+            .expect("new usage should accumulate after migration");
+        assert_cost(usage.window_5h, 9.0);
+        assert_cost(usage.window_week, 15.0);
+        assert_cost(usage.window_month, 18.0);
+
+        drop(db);
+        fs::remove_dir_all(dir).expect("test data dir should be removed");
+    }
+
+    #[test]
     fn fixed_window_5h_starts_at_first_success_and_expires_after_5h() {
         let dir = temp_data_dir("fixed-5h");
         let db = Database::open(dir.clone()).expect("db should open");
@@ -2584,6 +2813,26 @@ mod tests {
             (55..=65).contains(&remaining_min),
             "expected ~60min remaining, got {remaining_min}"
         );
+
+        drop(db);
+        fs::remove_dir_all(dir).expect("test data dir should be removed");
+    }
+
+    #[test]
+    fn fixed_window_treats_exact_end_as_the_next_window_start() {
+        let dir = temp_data_dir("fixed-boundary");
+        let db = Database::open(dir.clone()).expect("db should open");
+        db.create_account(&account("boundary"))
+            .expect("account should be created");
+
+        let first = Utc::now() - Duration::hours(5) - Duration::minutes(1);
+        let exact_end = first + Duration::hours(5);
+        finalize_success(&db, "boundary", 10.0, first);
+        finalize_success(&db, "boundary", 2.0, exact_end);
+
+        let usage = db.account_usage("boundary").expect("usage should load");
+        assert_cost(usage.window_5h, 2.0);
+        assert!(usage.resets_in_5h.is_some());
 
         drop(db);
         fs::remove_dir_all(dir).expect("test data dir should be removed");
@@ -2848,14 +3097,8 @@ mod tests {
 
         // 用户校准到 50%（月限额 100.0 → target_cost = 50.0）
         // 期望：offset = 50.0 - 5.0 = 45.0；compute_month_window 返回 45.0 + 5.0 = 50.0 = 50%。
-        db.calibrate_account_usage(
-            "monthly-calib",
-            UsageWindowKind::Month,
-            50.0,
-            None,
-            100.0,
-        )
-        .expect("month window calibrate should save");
+        db.calibrate_account_usage("monthly-calib", UsageWindowKind::Month, 50.0, None, 100.0)
+            .expect("month window calibrate should save");
         let usage = db
             .account_usage("monthly-calib")
             .expect("usage should load");

--- a/crates/ocg-core/src/gateway/forwarder.rs
+++ b/crates/ocg-core/src/gateway/forwarder.rs
@@ -1596,7 +1596,12 @@ mod stream_usage_tests {
         let mut st = StreamState::default();
         let payload =
             b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n".to_vec();
-        process_chunk_for_usage(&mut st, ApiFormat::ChatCompletions, &Bytes::from(payload), None);
+        process_chunk_for_usage(
+            &mut st,
+            ApiFormat::ChatCompletions,
+            &Bytes::from(payload),
+            None,
+        );
         assert!(!st.has_usage, "no usage field means no usage");
         assert!(st.buf.is_empty());
     }
@@ -1606,8 +1611,18 @@ mod stream_usage_tests {
         let mut st = StreamState::default();
         let first = b"data: {\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2}}\n\n".to_vec();
         let second = b"data: {\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":200,\"prompt_tokens_details\":{\"cached_tokens\":50}}}\n\n".to_vec();
-        process_chunk_for_usage(&mut st, ApiFormat::ChatCompletions, &Bytes::from(first), None);
-        process_chunk_for_usage(&mut st, ApiFormat::ChatCompletions, &Bytes::from(second), None);
+        process_chunk_for_usage(
+            &mut st,
+            ApiFormat::ChatCompletions,
+            &Bytes::from(first),
+            None,
+        );
+        process_chunk_for_usage(
+            &mut st,
+            ApiFormat::ChatCompletions,
+            &Bytes::from(second),
+            None,
+        );
         assert!(st.has_usage, "usage set");
         let (p, c, cached, cache_creation) = token_counts(st.usage);
         assert_eq!((p, c, cached, cache_creation), (100, 200, 50, 0));
@@ -1707,7 +1722,12 @@ mod stream_usage_tests {
         let mut st = StreamState::default();
         let payload =
             b"data: {\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":11}}\r\n\r\n".to_vec();
-        process_chunk_for_usage(&mut st, ApiFormat::ChatCompletions, &Bytes::from(payload), None);
+        process_chunk_for_usage(
+            &mut st,
+            ApiFormat::ChatCompletions,
+            &Bytes::from(payload),
+            None,
+        );
         assert!(st.has_usage, "CRLF usage should be parsed");
         let (p, c, _, _) = token_counts(st.usage);
         assert_eq!((p, c), (7, 11));

--- a/crates/ocg-core/src/gateway/protocol.rs
+++ b/crates/ocg-core/src/gateway/protocol.rs
@@ -1,10 +1,10 @@
+use crate::pricing::normalize_model_name;
 use axum::http::StatusCode;
 use base64::{
     Engine as _,
     engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
 };
 use bytes::Bytes;
-use crate::pricing::normalize_model_name;
 use serde_json::{Map, Value, json};
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -859,7 +859,10 @@ pub(crate) fn sanitize_minimax_chat_usage(
     let Some(obj) = usage.as_object_mut() else {
         return;
     };
-    let prompt = obj.get("prompt_tokens").and_then(Value::as_u64).unwrap_or(0);
+    let prompt = obj
+        .get("prompt_tokens")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
     let cached = obj
         .get("prompt_tokens_details")
         .and_then(|v| v.get("cached_tokens"))
@@ -905,11 +908,7 @@ pub fn has_complete_usage(format: ApiFormat, payload: &Value) -> bool {
     }
 }
 
-pub fn extract_usage(
-    format: ApiFormat,
-    payload: &Value,
-    model_hint: Option<&str>,
-) -> UsageCounts {
+pub fn extract_usage(format: ApiFormat, payload: &Value, model_hint: Option<&str>) -> UsageCounts {
     let usage = usage_payload(format, payload);
     let Some(usage) = usage else {
         return UsageCounts::default();
@@ -3901,8 +3900,7 @@ mod tests {
 
     #[test]
     fn minimax_bogus_all_cache_usage_is_sanitized() {
-        let mut usage =
-            json!({"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500});
+        let mut usage = json!({"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500});
         sanitize_minimax_anthropic_usage(Some("minimax-m3"), None, &mut usage);
         assert_eq!(usage["input_tokens"], 40500);
         assert_eq!(usage["cache_read_input_tokens"], 0);
@@ -3915,15 +3913,13 @@ mod tests {
         assert_eq!(usage["cache_read_input_tokens"], 14813);
 
         // The heuristic only applies to MiniMax models.
-        let mut usage =
-            json!({"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500});
+        let mut usage = json!({"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500});
         sanitize_minimax_anthropic_usage(Some("qwen3.7-max"), None, &mut usage);
         assert_eq!(usage["cache_read_input_tokens"], 40500);
 
         // OpenCode Go may return a non-MiniMax model identifier while the request plan still
         // points to MiniMax. The hint must still trigger sanitization.
-        let mut usage =
-            json!({"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500});
+        let mut usage = json!({"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500});
         sanitize_minimax_anthropic_usage(Some("ocg-generic"), Some("minimax-m3"), &mut usage);
         assert_eq!(usage["input_tokens"], 40500);
         assert_eq!(usage["cache_read_input_tokens"], 0);
@@ -3938,7 +3934,11 @@ mod tests {
             "usage":{"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500}
         });
         let chat = transform_response(
-            &plan_with_model(ApiFormat::ChatCompletions, ApiFormat::Messages, "minimax-m3"),
+            &plan_with_model(
+                ApiFormat::ChatCompletions,
+                ApiFormat::Messages,
+                "minimax-m3",
+            ),
             &response,
         )
         .expect("Messages to Chat");
@@ -3957,7 +3957,11 @@ mod tests {
             "usage":{"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500}
         });
         let chat = transform_response(
-            &plan_with_model(ApiFormat::ChatCompletions, ApiFormat::Messages, "minimax-m3"),
+            &plan_with_model(
+                ApiFormat::ChatCompletions,
+                ApiFormat::Messages,
+                "minimax-m3",
+            ),
             &response,
         )
         .expect("Messages to Chat");
@@ -4055,33 +4059,37 @@ mod tests {
             }
         });
         let converted = transform_response(
-            &plan_with_model(ApiFormat::ChatCompletions, ApiFormat::ChatCompletions, "minimax-m3"),
+            &plan_with_model(
+                ApiFormat::ChatCompletions,
+                ApiFormat::ChatCompletions,
+                "minimax-m3",
+            ),
             &response,
         )
         .expect("Chat Completions passthrough should sanitize");
         assert_eq!(converted["usage"]["prompt_tokens"], 40669);
-        assert_eq!(converted["usage"]["prompt_tokens_details"]["cached_tokens"], 0);
+        assert_eq!(
+            converted["usage"]["prompt_tokens_details"]["cached_tokens"],
+            0
+        );
     }
 
     #[test]
     fn minimax_model_detection_is_case_and_separator_insensitive() {
         // OpenCode Go / Qwen Cloud docs expose MiniMax IDs with capital letters (MiniMax-M3).
         // The sanitizer must still recognize them.
-        let mut usage =
-            json!({"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500});
+        let mut usage = json!({"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500});
         sanitize_minimax_anthropic_usage(Some("MiniMax-M3"), None, &mut usage);
         assert_eq!(usage["input_tokens"], 40500);
         assert_eq!(usage["cache_read_input_tokens"], 0);
 
-        let mut usage =
-            json!({"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500});
+        let mut usage = json!({"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500});
         sanitize_minimax_anthropic_usage(Some("ocg-generic"), Some("MiniMax_M3"), &mut usage);
         assert_eq!(usage["input_tokens"], 40500);
         assert_eq!(usage["cache_read_input_tokens"], 0);
 
         // Qwen is unaffected.
-        let mut usage =
-            json!({"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500});
+        let mut usage = json!({"input_tokens":0,"output_tokens":5,"cache_read_input_tokens":40500});
         sanitize_minimax_anthropic_usage(Some("Qwen3.7-Max"), None, &mut usage);
         assert_eq!(usage["cache_read_input_tokens"], 40500);
     }

--- a/crates/ocg-core/src/gateway/protocol_stream.rs
+++ b/crates/ocg-core/src/gateway/protocol_stream.rs
@@ -1,7 +1,7 @@
 use super::protocol::{
-    ApiFormat, NamespaceToolMapping, ProtocolError, RequestPlan,
-    encode_anthropic_thinking_block, encode_chat_reasoning, responses_id,
-    sanitize_minimax_anthropic_usage, sanitize_minimax_chat_usage, unix_seconds,
+    ApiFormat, NamespaceToolMapping, ProtocolError, RequestPlan, encode_anthropic_thinking_block,
+    encode_chat_reasoning, responses_id, sanitize_minimax_anthropic_usage,
+    sanitize_minimax_chat_usage, unix_seconds,
 };
 use bytes::{Bytes, BytesMut};
 use serde_json::{Map, Value, json};
@@ -171,8 +171,8 @@ impl StreamConverter {
             self.pending.extend_from_slice(&chunk);
             let frames = drain_frames(&mut self.pending);
             let mut output = Vec::new();
-            let sanitize_passthrough =
-                self.source == ApiFormat::ChatCompletions && self.target == ApiFormat::ChatCompletions;
+            let sanitize_passthrough = self.source == ApiFormat::ChatCompletions
+                && self.target == ApiFormat::ChatCompletions;
             for frame in frames {
                 if self.input.terminal {
                     break;
@@ -2323,7 +2323,9 @@ mod tests {
         };
         let mut converter = StreamConverter::new(&plan);
         let bytes = source.as_bytes();
-        let mut output = converter.process_chunk(Bytes::copy_from_slice(bytes)).unwrap();
+        let mut output = converter
+            .process_chunk(Bytes::copy_from_slice(bytes))
+            .unwrap();
         output.extend(converter.finish().unwrap());
         let output = String::from_utf8(output.concat()).unwrap();
         assert!(output.contains("\"prompt_tokens\":40500"));
@@ -2354,7 +2356,9 @@ mod tests {
         };
         let mut converter = StreamConverter::new(&plan);
         let bytes = source.as_bytes();
-        let mut output = converter.process_chunk(Bytes::copy_from_slice(bytes)).unwrap();
+        let mut output = converter
+            .process_chunk(Bytes::copy_from_slice(bytes))
+            .unwrap();
         output.extend(converter.finish().unwrap());
         let output = String::from_utf8(output.concat()).unwrap();
         assert!(output.contains("\"prompt_tokens\":40500"));
@@ -2385,7 +2389,9 @@ mod tests {
         };
         let mut converter = StreamConverter::new(&plan);
         let bytes = source.as_bytes();
-        let mut output = converter.process_chunk(Bytes::copy_from_slice(bytes)).unwrap();
+        let mut output = converter
+            .process_chunk(Bytes::copy_from_slice(bytes))
+            .unwrap();
         output.extend(converter.finish().unwrap());
         let output = String::from_utf8(output.concat()).unwrap();
         assert!(output.contains("\"prompt_tokens\":40500"));

--- a/src/views/Accounts.vue
+++ b/src/views/Accounts.vue
@@ -373,10 +373,12 @@ import {
   isWindowCooling,
   mergeUsageEdit,
   normalizeUsagePercent,
+  resetsInMinutesForSave,
   usagePercentFromCost,
   usageProgressPercentage,
   usageProgressStatus,
   WINDOW_FULL_MINUTES,
+  windowResetsAt,
 } from "./accounts-usage";
 import type { UsageEditState, UsageKey } from "./accounts-usage";
 import { daysUntilDate, expiryTagType, moveItem } from "./account-lifecycle";
@@ -486,7 +488,8 @@ function usageEditsFromWindow(usage: UsageWindow): AccountUsageEdits {
       saving: false,
       error: null,
       resets_in_minutes_draft: resetsInMin,
-      resets_in_minutes_saved: resetsInMin,
+      resets_at_saved: windowResetsAt(usage, key),
+      resets_dirty: false,
     }];
   })) as AccountUsageEdits;
 }
@@ -503,15 +506,17 @@ function syncUsageEdits(accountId: string, usage: UsageWindow) {
     const edit = existing[key];
     const wasActuallyReset = account && isUsageLimitReached(account, key, now.value);
     if (!edit) {
-      existing[key] = mergeUsageEdit(undefined, saved, Boolean(wasActuallyReset));
+      const created = mergeUsageEdit(undefined, saved, Boolean(wasActuallyReset));
+      created.resets_in_minutes_draft = defaultResetsInMinutes(usage, key, now.value);
+      created.resets_at_saved = windowResetsAt(usage, key);
+      existing[key] = created;
       continue;
     }
     Object.assign(edit, mergeUsageEdit(edit, saved, Boolean(wasActuallyReset)));
-    // 同步 resets_in_minutes_saved；draft 未被用户改动时跟着 saved 走。
-    const resetsInMin = defaultResetsInMinutes(usage, key, now.value);
-    edit.resets_in_minutes_saved = resetsInMin;
-    if (edit.resets_in_minutes_draft === null || !edit.saving && edit.resets_in_minutes_draft === edit.resets_in_minutes_saved) {
-      edit.resets_in_minutes_draft = resetsInMin;
+    edit.resets_at_saved = windowResetsAt(usage, key);
+    if (wasActuallyReset || (!edit.saving && !edit.resets_dirty)) {
+      edit.resets_in_minutes_draft = defaultResetsInMinutes(usage, key, now.value);
+      edit.resets_dirty = false;
     }
   }
 }
@@ -588,6 +593,7 @@ function updateResetsFirstField(accountId: string, key: UsageKey, value: number 
   const second = resetsSecondField(accountId, key);
   const max = WINDOW_FULL_MINUTES[key] ?? 10080;
   edit.resets_in_minutes_draft = Math.min(max, fieldsToMinutes(v, second, key));
+  edit.resets_dirty = true;
 }
 
 function updateResetsSecondField(accountId: string, key: UsageKey, value: number | null) {
@@ -598,6 +604,7 @@ function updateResetsSecondField(accountId: string, key: UsageKey, value: number
   const first = resetsFirstField(accountId, key);
   const max = WINDOW_FULL_MINUTES[key] ?? 10080;
   edit.resets_in_minutes_draft = Math.min(max, fieldsToMinutes(first, v, key));
+  edit.resets_dirty = true;
 }
 
 async function saveUsage(accountId: string, key: UsageKey) {
@@ -605,21 +612,17 @@ async function saveUsage(accountId: string, key: UsageKey) {
   if (!edit || edit.saving) return;
   const percent = normalizeUsagePercent(edit.draft);
   edit.draft = percent;
-  const resetsChanged = edit.resets_in_minutes_draft !== edit.resets_in_minutes_saved;
+  const resetsChanged = edit.resets_dirty;
   if (percent === edit.saved && !resetsChanged && !edit.error) return;
   edit.saving = true;
   edit.error = null;
-  // ponytail: Bug 3 — 之前用 defaultResetsInMinutes(usage, key, now.value) 重算剩余分钟，
-  // 由于 now.value（每秒刷新的 Vue ref）始终 ≤ backend 处理请求时的 Utc::now()，
-  // Math.ceil((ends_at - now)/60000) 会向上取整多出 1 分钟，每次保存累加。
-  // 直接回写用户输入的值，这就是发给后端的值，无需重算。
-  const userResetsInMin = edit.resets_in_minutes_draft;
+  const resetsInMin = resetsInMinutesForSave(edit, key);
   try {
     const usage = await tauriApi.updateAccountUsage(
       accountId,
       key,
       percent,
-      WINDOW_FULL_MINUTES[key] === null ? null : userResetsInMin,
+      resetsInMin,
     );
     usageMap.value[accountId] = {
       ...getUsage(accountId),
@@ -631,8 +634,9 @@ async function saveUsage(accountId: string, key: UsageKey) {
     const saved = usagePercentFromCost(usage[key], usageLimit(key));
     edit.draft = saved;
     edit.saved = saved;
-    edit.resets_in_minutes_draft = userResetsInMin;
-    edit.resets_in_minutes_saved = userResetsInMin;
+    edit.resets_at_saved = windowResetsAt(usage, key);
+    edit.resets_in_minutes_draft = defaultResetsInMinutes(usage, key);
+    edit.resets_dirty = false;
   } catch (error) {
     edit.error = errorDetail(error);
   } finally {

--- a/src/views/Logs.vue
+++ b/src/views/Logs.vue
@@ -218,12 +218,12 @@ import type { Account, ForwardLog, ForwardLogSummary, GatewayLog } from "../api/
 import { t } from "../i18n/index.ts";
 import { locale } from "../i18n/index.ts";
 import { formatCost, formatNumber, useClipboard } from "../utils/format.ts";
+import { computeTimeRange, resolveTimeRange, timePresetValues } from "./log-time-range.ts";
+import type { TimePreset } from "./log-time-range.ts";
 
 type LogTab = "gateway" | "forward";
 type SortBy = "timestamp" | "prompt_tokens" | "completion_tokens" | "cached_tokens" | "cost";
 type SortOrder = "asc" | "desc";
-type TimePreset = "all" | "last24h" | "last7d" | "last30d" | "thisMonth" | "lastMonth" | "custom";
-
 const sortValues = new Set<SortBy>([
   "timestamp",
   "prompt_tokens",
@@ -263,8 +263,15 @@ function parseQueryTimeRange(): [number, number] | null {
 }
 
 const initialTimeRange = parseQueryTimeRange();
-const initialPreset: TimePreset = initialTimeRange ? "custom" : "last24h";
-const initialRange = initialTimeRange ?? computeTimeRange("last24h");
+const queryPreset = query.get("range");
+const initialPreset: TimePreset = initialTimeRange
+  ? "custom"
+  : queryPreset !== null
+      && queryPreset !== "custom"
+      && timePresetValues.has(queryPreset as TimePreset)
+    ? queryPreset as TimePreset
+    : "last24h";
+const initialRange = initialTimeRange ?? resolveTimeRange(initialPreset, null);
 const timeRange = ref<[number, number] | null>(initialRange);
 const activePreset = ref<TimePreset>(initialPreset);
 const customTimeRange = ref<[number, number] | null>(initialRange);
@@ -328,10 +335,10 @@ const statusMeta = computed<Record<string, { label: string; type: "success" | "w
   client_error: { label: t("客户端错误"), type: "error" },
   error: { label: t("错误"), type: "error" },
 }));
-const allOption = { label: t("全部"), value: "" };
-const statusOptions = computed(() => [allOption, ...Object.entries(statusMeta.value).map(([value, meta]) => ({ label: meta.label, value }))]);
-const accountOptions = computed(() => [allOption, ...accounts.value.map((account) => ({ label: account.name, value: account.id }))]);
-const modelOptions = computed(() => [allOption, ...models.value.map((model) => ({ label: model, value: model }))]);
+const allOption = computed(() => ({ label: t("全部"), value: "" }));
+const statusOptions = computed(() => [allOption.value, ...Object.entries(statusMeta.value).map(([value, meta]) => ({ label: meta.label, value }))]);
+const accountOptions = computed(() => [allOption.value, ...accounts.value.map((account) => ({ label: account.name, value: account.id }))]);
+const modelOptions = computed(() => [allOption.value, ...models.value.map((model) => ({ label: model, value: model }))]);
 const sortOptions = computed(() => [
   { label: t("时间"), value: "timestamp" },
   { label: t("输入"), value: "prompt_tokens" },
@@ -355,40 +362,12 @@ function toIsoString(ms: number): string {
   return new Date(ms).toISOString();
 }
 
-function startOfLocalMonth(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth(), 1, 0, 0, 0, 0);
-}
-
-function endOfLocalMonth(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth() + 1, 0, 23, 59, 59, 999);
-}
-
-function computeTimeRange(preset: TimePreset): [number, number] | null {
-  const now = new Date();
-  const end = now.getTime();
-  switch (preset) {
-    case "last24h":
-      return [end - 24 * 60 * 60 * 1000, end];
-    case "last7d":
-      return [end - 7 * 24 * 60 * 60 * 1000, end];
-    case "last30d":
-      return [end - 30 * 24 * 60 * 60 * 1000, end];
-    case "thisMonth":
-      return [startOfLocalMonth(now).getTime(), end];
-    case "lastMonth": {
-      const firstDayThisMonth = startOfLocalMonth(now);
-      const lastDayPrevMonth = new Date(firstDayThisMonth.getTime() - 1);
-      return [startOfLocalMonth(lastDayPrevMonth).getTime(), endOfLocalMonth(lastDayPrevMonth).getTime()];
-    }
-    default:
-      return null;
-  }
-}
-
 function applyTimePreset(preset: TimePreset) {
   if (preset === "custom") {
+    const currentRange = resolveTimeRange(activePreset.value, timeRange.value);
     activePreset.value = "custom";
-    customTimeRange.value = timeRange.value;
+    timeRange.value = currentRange;
+    customTimeRange.value = currentRange;
     showTimePanel.value = true;
     return;
   }
@@ -400,12 +379,10 @@ function applyTimePreset(preset: TimePreset) {
     return;
   }
   const range = computeTimeRange(preset);
-  if (range) {
-    activePreset.value = preset;
-    timeRange.value = range;
-    customTimeRange.value = range;
-    showTimePanel.value = false;
-  }
+  activePreset.value = preset;
+  timeRange.value = range;
+  customTimeRange.value = range;
+  showTimePanel.value = false;
 }
 
 function applyCustomTimeRange(value: [number, number] | null) {
@@ -491,10 +468,9 @@ function clearFilters() {
   statusFilter.value = "";
   accountFilter.value = "";
   modelFilter.value = "";
-  activePreset.value = "last24h";
-  const range = computeTimeRange("last24h");
-  timeRange.value = range;
-  customTimeRange.value = range;
+  activePreset.value = "all";
+  timeRange.value = null;
+  customTimeRange.value = null;
   showTimePanel.value = false;
 }
 
@@ -511,12 +487,14 @@ function syncQueryState() {
   else url.searchParams.delete("account");
   if (modelFilter.value) url.searchParams.set("model", modelFilter.value);
   else url.searchParams.delete("model");
-  if (timeRange.value) {
+  if (activePreset.value === "custom" && timeRange.value) {
     url.searchParams.set("start", toIsoString(timeRange.value[0]));
     url.searchParams.set("end", toIsoString(timeRange.value[1]));
+    url.searchParams.delete("range");
   } else {
     url.searchParams.delete("start");
     url.searchParams.delete("end");
+    url.searchParams.set("range", activePreset.value);
   }
   if (sortBy.value) url.searchParams.set("sort", sortBy.value);
   else url.searchParams.delete("sort");
@@ -547,14 +525,15 @@ async function loadForwardLogs() {
   forwardLogs.value = [];
   forwardTotals.value = emptySummary();
   try {
+    const requestRange = resolveTimeRange(activePreset.value, timeRange.value);
     const result = await tauriApi.getForwardLogs({
       limit: pageSize,
       offset: (forwardPage.value - 1) * pageSize,
       status: statusFilter.value,
       account_id: accountFilter.value,
       model: modelFilter.value,
-      start_time: timeRange.value ? toIsoString(timeRange.value[0]) : null,
-      end_time: timeRange.value ? toIsoString(timeRange.value[1]) : null,
+      start_time: requestRange ? toIsoString(requestRange[0]) : null,
+      end_time: requestRange ? toIsoString(requestRange[1]) : null,
       sort_by: sortBy.value,
       sort_order: sortOrder.value,
     });
@@ -603,7 +582,7 @@ function changeGatewayPage(page: number) {
 
 watch(activeTab, syncQueryState);
 watch(
-  [statusFilter, accountFilter, modelFilter, timeRange, sortBy, sortOrder],
+  [statusFilter, accountFilter, modelFilter, timeRange, activePreset, sortBy, sortOrder],
   () => {
     forwardPage.value = 1;
     syncQueryState();

--- a/src/views/accounts-usage.test.ts
+++ b/src/views/accounts-usage.test.ts
@@ -6,6 +6,7 @@ import {
   isUsageLimitReached,
   mergeUsageEdit,
   normalizeUsagePercent,
+  resetsInMinutesForSave,
   usagePercentFromCost,
   usageProgressPercentage,
   usageProgressStatus,
@@ -151,7 +152,8 @@ test("usage refresh preserves dirty drafts unless a real 429 reset that window",
     saving: false,
     error: "save failed",
     resets_in_minutes_draft: 240,
-    resets_in_minutes_saved: 200,
+    resets_at_saved: "2099-01-01T00:00:00Z",
+    resets_dirty: true,
   };
 
   assert.deepEqual(mergeUsageEdit(dirty, 35, false), {
@@ -160,7 +162,8 @@ test("usage refresh preserves dirty drafts unless a real 429 reset that window",
     saving: false,
     error: "save failed",
     resets_in_minutes_draft: 240,
-    resets_in_minutes_saved: 200,
+    resets_at_saved: "2099-01-01T00:00:00Z",
+    resets_dirty: true,
   });
   assert.deepEqual(mergeUsageEdit(dirty, 0, true), {
     draft: 0,
@@ -168,7 +171,8 @@ test("usage refresh preserves dirty drafts unless a real 429 reset that window",
     saving: false,
     error: null,
     resets_in_minutes_draft: 240,
-    resets_in_minutes_saved: 200,
+    resets_at_saved: "2099-01-01T00:00:00Z",
+    resets_dirty: true,
   });
   assert.deepEqual(mergeUsageEdit(undefined, 35, false), {
     draft: 35,
@@ -176,8 +180,36 @@ test("usage refresh preserves dirty drafts unless a real 429 reset that window",
     saving: false,
     error: null,
     resets_in_minutes_draft: null,
-    resets_in_minutes_saved: null,
+    resets_at_saved: null,
+    resets_dirty: false,
   });
+});
+
+test("percent-only usage saves keep counting down from the backend deadline", () => {
+  const resetAt = "2026-07-19T12:05:30Z";
+  const clean: UsageEditState = {
+    draft: 50,
+    saved: 40,
+    saving: false,
+    error: null,
+    resets_in_minutes_draft: 6,
+    resets_at_saved: resetAt,
+    resets_dirty: false,
+  };
+
+  assert.equal(
+    resetsInMinutesForSave(clean, "window_5h", Date.parse("2026-07-19T12:00:00Z")),
+    5,
+  );
+  assert.equal(
+    resetsInMinutesForSave(clean, "window_5h", Date.parse("2026-07-19T12:02:00Z")),
+    3,
+  );
+  assert.equal(
+    resetsInMinutesForSave({ ...clean, resets_in_minutes_draft: 240, resets_dirty: true }, "window_5h"),
+    240,
+  );
+  assert.equal(resetsInMinutesForSave(clean, "window_month"), null);
 });
 
 test("usage refresh initializes windows missing after an earlier quota load failure", async () => {
@@ -186,7 +218,7 @@ test("usage refresh initializes windows missing after an earlier quota load fail
 
   assert.match(
     sync,
-    /if \(!edit\) \{\s+existing\[key\] = mergeUsageEdit\(undefined, saved, Boolean\(wasActuallyReset\)\);\s+continue;/,
+    /if \(!edit\) \{\s+const created = mergeUsageEdit\(undefined, saved, Boolean\(wasActuallyReset\)\);/,
   );
   assert.ok(sync.indexOf("if (!edit)") < sync.indexOf("Object.assign(edit"));
 });
@@ -221,6 +253,8 @@ test("manual editor writes on commit events instead of each value update", async
   assert.match(source, /@blur="saveUsage\(account\.id, limit\.key\)"/);
   assert.match(source, /@keydown\.enter\.prevent="saveUsage\(account\.id, limit\.key\)"/);
   assert.match(source, /if \(!edit \|\| edit\.saving\) return;/);
+  assert.equal(source.match(/edit\.resets_dirty = true;/g)?.length, 2);
+  assert.match(source, /const resetsInMin = resetsInMinutesForSave\(edit, key\)/);
 });
 
 test("account drag keeps receiving touch pointers after keyed cards move", async () => {

--- a/src/views/accounts-usage.ts
+++ b/src/views/accounts-usage.ts
@@ -9,7 +9,9 @@ export type UsageEditState = {
   error: string | null;
   /// 手动校准的"距上游重置还剩多少分钟"。仅 5h/周窗口使用；月窗口始终为 null。
   resets_in_minutes_draft: number | null;
-  resets_in_minutes_saved: number | null;
+  /// 最近一次从后端读到的绝对重置时刻。未手动改时间时，保存前由它重新计算剩余分钟。
+  resets_at_saved: string | null;
+  resets_dirty: boolean;
 };
 
 /// 5h/周窗口的满窗分钟数。月窗口无法手动校准时间。
@@ -28,6 +30,22 @@ export function defaultResetsInMinutes(usage: Pick<UsageWindow, "resets_in_5h" |
   if (!until) return full;
   const remainingMs = Date.parse(until) - now;
   return Math.max(0, Math.ceil(remainingMs / 60000));
+}
+
+export function resetsInMinutesForSave(
+  edit: Pick<UsageEditState, "resets_in_minutes_draft" | "resets_at_saved" | "resets_dirty">,
+  key: UsageKey,
+  now = Date.now(),
+): number | null {
+  const full = WINDOW_FULL_MINUTES[key];
+  if (full === null) return null;
+  if (edit.resets_dirty) return edit.resets_in_minutes_draft;
+  if (!edit.resets_at_saved) return full;
+  const remainingMs = Date.parse(edit.resets_at_saved) - now;
+  // The backend starts a fresh integer-minute deadline when it receives the
+  // calibration. Floor prevents a percent-only save from extending the old
+  // absolute deadline by the fractional minute already elapsed in this page.
+  return Math.max(0, Math.floor(remainingMs / 60000));
 }
 
 const cooldownFields: Record<UsageKey, keyof Pick<Account, "cooldown_5h_until" | "cooldown_week_until" | "cooldown_month_until">> = {
@@ -99,7 +117,8 @@ export function mergeUsageEdit(
       saving: false,
       error: null,
       resets_in_minutes_draft: null,
-      resets_in_minutes_saved: null,
+      resets_at_saved: null,
+      resets_dirty: false,
     };
   }
   if (!force && (edit.saving || edit.draft !== edit.saved)) {

--- a/src/views/log-time-range.ts
+++ b/src/views/log-time-range.ts
@@ -1,0 +1,61 @@
+export type TimePreset =
+  | "all"
+  | "last24h"
+  | "last7d"
+  | "last30d"
+  | "thisMonth"
+  | "lastMonth"
+  | "custom";
+
+export const timePresetValues = new Set<TimePreset>([
+  "all",
+  "last24h",
+  "last7d",
+  "last30d",
+  "thisMonth",
+  "lastMonth",
+  "custom",
+]);
+
+function startOfLocalMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1, 0, 0, 0, 0);
+}
+
+function endOfLocalMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0, 23, 59, 59, 999);
+}
+
+export function computeTimeRange(
+  preset: Exclude<TimePreset, "all" | "custom">,
+  now = new Date(),
+): [number, number] {
+  const end = now.getTime();
+  switch (preset) {
+    case "last24h":
+      return [end - 24 * 60 * 60 * 1000, end];
+    case "last7d":
+      return [end - 7 * 24 * 60 * 60 * 1000, end];
+    case "last30d":
+      return [end - 30 * 24 * 60 * 60 * 1000, end];
+    case "thisMonth":
+      return [startOfLocalMonth(now).getTime(), end];
+    case "lastMonth": {
+      const firstDayThisMonth = startOfLocalMonth(now);
+      const lastDayPrevMonth = new Date(firstDayThisMonth.getTime() - 1);
+      return [
+        startOfLocalMonth(lastDayPrevMonth).getTime(),
+        endOfLocalMonth(lastDayPrevMonth).getTime(),
+      ];
+    }
+  }
+}
+
+export function resolveTimeRange(
+  preset: TimePreset,
+  customRange: [number, number] | null,
+  now = new Date(),
+): [number, number] | null {
+  if (preset === "all") return null;
+  if (preset === "custom") return customRange;
+  return computeTimeRange(preset, now);
+}

--- a/src/views/logs.test.ts
+++ b/src/views/logs.test.ts
@@ -2,6 +2,7 @@
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { DashboardRequestError, tauriApi } from "../api/tauri.ts";
+import { computeTimeRange, resolveTimeRange } from "./log-time-range.ts";
 
 test("forward log API sends remote paging and filter parameters", async () => {
   let requested = "";
@@ -245,15 +246,47 @@ test("logs time range selector renders presets and custom picker in a popover", 
 });
 
 test("logs time range helpers cover all presets", async () => {
-  const source = await readFile(new URL("./Logs.vue", import.meta.url), "utf8");
-  const script = source.slice(source.indexOf("<script setup"), source.indexOf("</script>"));
+  const now = new Date(2026, 6, 19, 12, 0, 0, 0);
+  assert.deepEqual(computeTimeRange("last24h", now), [
+    now.getTime() - 24 * 60 * 60 * 1000,
+    now.getTime(),
+  ]);
+  assert.deepEqual(computeTimeRange("last7d", now), [
+    now.getTime() - 7 * 24 * 60 * 60 * 1000,
+    now.getTime(),
+  ]);
+  assert.deepEqual(computeTimeRange("last30d", now), [
+    now.getTime() - 30 * 24 * 60 * 60 * 1000,
+    now.getTime(),
+  ]);
+  assert.deepEqual(computeTimeRange("thisMonth", now), [
+    new Date(2026, 6, 1).getTime(),
+    now.getTime(),
+  ]);
+  assert.deepEqual(computeTimeRange("lastMonth", now), [
+    new Date(2026, 5, 1).getTime(),
+    new Date(2026, 5, 30, 23, 59, 59, 999).getTime(),
+  ]);
+});
 
-  assert.match(script, /function computeTimeRange\(preset: TimePreset\)/);
-  assert.match(script, /case "last24h":/);
-  assert.match(script, /case "last7d":/);
-  assert.match(script, /case "last30d":/);
-  assert.match(script, /case "thisMonth":/);
-  assert.match(script, /case "lastMonth":/);
-  assert.match(script, /function startOfLocalMonth/);
-  assert.match(script, /function endOfLocalMonth/);
+test("rolling log presets resolve against the current refresh time", async () => {
+  const first = new Date("2026-07-19T00:00:00Z");
+  const later = new Date("2026-07-19T03:00:00Z");
+  const staleSelection = computeTimeRange("last24h", first);
+
+  assert.deepEqual(resolveTimeRange("last24h", staleSelection, later), computeTimeRange("last24h", later));
+  assert.deepEqual(resolveTimeRange("custom", staleSelection, later), staleSelection);
+  assert.equal(resolveTimeRange("all", staleSelection, later), null);
+
+  const source = await readFile(new URL("./Logs.vue", import.meta.url), "utf8");
+  const forwardLoad = source.slice(
+    source.indexOf("async function loadForwardLogs"),
+    source.indexOf("async function loadAccounts"),
+  );
+  assert.match(forwardLoad, /resolveTimeRange\(activePreset\.value, timeRange\.value\)/);
+  assert.match(source, /url\.searchParams\.set\("range", activePreset\.value\)/);
+
+  const clearFilters = source.slice(source.indexOf("function clearFilters"), source.indexOf("function toggleSortOrder"));
+  assert.match(clearFilters, /activePreset\.value = "all"/);
+  assert.match(clearFilters, /timeRange\.value = null/);
 });


### PR DESCRIPTION
## Summary

- fix rolling log presets so refreshes include newly arrived rows, make translated “All” options reactive, and make Clear remove the time filter
- keep account reset deadlines stable on percent-only edits, preserve legacy manual calibrations through schema v13, and handle exact fixed-window boundaries
- harden non-stream and streaming usage extraction, including MiniMax cache normalization and terminal stream handling
- apply the Rust formatting required by the quality workflow

## Why

This is a focused follow-up to #22. It keeps the merged feature behavior while fixing edge cases found during post-merge review.

## Validation

- `pnpm run test:web` — 106 passed
- `cargo test --workspace --locked` — all workspace tests passed (one live-network test ignored by design)
- `cargo fmt --all -- --check`