### PR TITLE
fix: allow verifier to inspect draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,7 +454,7 @@ jobs:
       asset_digest: ${{ steps.asset_metadata.outputs.digest }}
       release_id: ${{ steps.asset_metadata.outputs.release_id }}
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/scripts/release-policy.test.mjs
+++ b/scripts/release-policy.test.mjs
@@ -108,6 +108,7 @@ test("the exact draft Release identity flows through verification and publicatio
   assert.match(draftJob, /- name: Create or update draft release\s+id: release/);
   assert.match(draftJob, /gh release view "\$GITHUB_REF_NAME" --json databaseId,isDraft,tagName/);
   assert.match(verifyJob, /release_id: \$\{\{ steps\.asset_metadata\.outputs\.release_id \}\}/);
+  assert.match(verifyJob, /permissions:\s+contents: write/);
   assert.match(verifyJob, /RELEASE_ID: \$\{\{ needs\.draft-release\.outputs\.release_id \}\}/);
   assert.match(verifyJob, /if gh api "repos\/\$GITHUB_REPOSITORY\/releases\/\$RELEASE_ID"/);
   assert.match(verifyJob, /\.id == \$release_id and \.tag_name == \$tag and \.draft == true/);


### PR DESCRIPTION
## Summary

Fix the production release verifier after the v1.5.1 tag run reached the Draft verification stage and GitHub returned:

```
gh: Resource not accessible by integration (HTTP 403)
```

`verify-release` must inspect an unpublished Draft Release by its exact ID. GitHub does not expose Draft Release metadata to the job's previous read-only token, so scope `contents: write` only to this verifier job. The workflow-wide default remains `contents: read`.

A release-policy regression assertion now locks in the required job-level permission.

## Verification

- `node --test scripts/generate-updater-manifest.test.mjs scripts/release-policy.test.mjs scripts/verify-release-assets.test.mjs` (25/25)
- `pnpm run release:check`
- independent v1.5.1 verification: all 15 assets, SHA256SUMS, updater manifest, four signatures, and GitHub server digests passed

The already-published v1.5.1 assets are unchanged; this PR fixes future tag releases.