### PR TITLE
fix: remove bundled libwayland-* from Linux AppImage to fix Arch compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libxdo-dev libssl-dev patchelf libfuse2 xvfb xauth xdg-utils dbus-x11
 
+      - name: Download appimagetool (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          mkdir -p .tools
+          curl -fSL -o .tools/appimagetool "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+          chmod +x .tools/appimagetool
+          echo "APPIMAGETOOL=$(pwd)/.tools/appimagetool" >> "$GITHUB_ENV"
+
       - name: Install macOS Rust targets
         if: runner.os == 'macOS'
         run: rustup target add x86_64-apple-darwin aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
         shell: pwsh
         run: ./scripts/validate-windows-release-smoke.ps1
       - name: Test release helpers
-        run: node --test scripts/generate-updater-manifest.test.mjs scripts/release-policy.test.mjs scripts/verify-release-assets.test.mjs
+        run: node --test scripts/generate-updater-manifest.test.mjs scripts/release-policy.test.mjs scripts/verify-release-assets.test.mjs scripts/prune-appimage-wayland-libs.test.mjs
       - name: Validate version and unsigned candidate contract
         run: pnpm run release:check
 
@@ -131,9 +131,20 @@ jobs:
 
       - name: Download appimagetool (Linux)
         if: runner.os == 'Linux'
+        env:
+          APPIMAGETOOL_VERSION: "1.9.1"
+          APPIMAGETOOL_SHA256: "ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0"
         run: |
           mkdir -p .tools
-          curl -fSL -o .tools/appimagetool "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+          curl -fSL -o .tools/appimagetool "https://github.com/AppImage/appimagetool/releases/download/v${APPIMAGETOOL_VERSION}/appimagetool-x86_64.AppImage"
+          actual=$(sha256sum .tools/appimagetool | cut -d' ' -f1)
+          if [ "$actual" != "$APPIMAGETOOL_SHA256" ]; then
+            echo "SHA-256 mismatch for appimagetool v${APPIMAGETOOL_VERSION}" >&2
+            echo "Expected: $APPIMAGETOOL_SHA256" >&2
+            echo "Actual:   $actual" >&2
+            exit 1
+          fi
+          echo "appimagetool v${APPIMAGETOOL_VERSION} SHA-256 verified."
           chmod +x .tools/appimagetool
           echo "APPIMAGETOOL=$(pwd)/.tools/appimagetool" >> "$GITHUB_ENV"
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:web": "vue-tsc && vite build",
     "release:check": "node scripts/release.mjs --check",
     "test:rust": "cargo test --workspace --locked",
-    "test:web": "node --experimental-strip-types --test scripts/generate-updater-manifest.test.mjs scripts/release-policy.test.mjs scripts/verify-release-assets.test.mjs src/i18n.test.ts src/views/account-lifecycle.test.ts src/views/accounts-usage.test.ts src/views/dashboard-connection.test.ts src/views/pricing-view.test.ts src/views/settings-update.test.ts src/views/logs.test.ts src/components/stacked-bar-chart.test.ts src/theme.test.ts",
+    "test:web": "node --experimental-strip-types --test scripts/generate-updater-manifest.test.mjs scripts/release-policy.test.mjs scripts/verify-release-assets.test.mjs scripts/prune-appimage-wayland-libs.test.mjs src/i18n.test.ts src/views/account-lifecycle.test.ts src/views/accounts-usage.test.ts src/views/dashboard-connection.test.ts src/views/pricing-view.test.ts src/views/settings-update.test.ts src/views/logs.test.ts src/components/stacked-bar-chart.test.ts src/theme.test.ts",
     "typecheck": "vue-tsc --noEmit",
     "test": "pnpm run test:web && pnpm run typecheck && pnpm exec vite build && pnpm run test:rust",
     "design:lint": "npx -y @google/design.md@0.3.0 lint DESIGN.md"

--- a/scripts/prune-appimage-wayland-libs.mjs
+++ b/scripts/prune-appimage-wayland-libs.mjs
@@ -2,6 +2,84 @@ import { existsSync, mkdirSync, readdirSync, rmSync, renameSync } from "node:fs"
 import { basename, join } from "node:path";
 import { spawnSync } from "node:child_process";
 
+export const SECRET_ENV_PATTERNS = [
+  "TAURI_SIGNING_PRIVATE_KEY",
+  "TAURI_SIGNING_PRIVATE_KEY_PASSWORD",
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "ACTIONS_RUNTIME_TOKEN",
+  "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+  "SIGNING_SECRET",
+  "NODE_EXTRA_CA_CERTS",
+  "NPM_TOKEN",
+  "CARGO_REGISTRY_TOKEN",
+  "DOCKER_PASSWORD",
+  "DOCKER_TOKEN",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+];
+
+/**
+ * Build a sanitized environment for the appimagetool subprocess.
+ *
+ * The default environment contains signing keys, CI tokens, and other secrets
+ * that should never be passed to an external binary. This function starts from
+ * an empty object and only copies known-safe variables, preventing any secret
+ * from leaking to appimagetool.
+ *
+ * @returns {Record<string, string>}
+ */
+export function sanitizedEnv() {
+  const safe = {};
+
+  const safeKeys = new Set([
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "LC_MESSAGES",
+    "XDG_RUNTIME_DIR",
+    "DISPLAY",
+    "WAYLAND_DISPLAY",
+    "DBUS_SESSION_BUS_ADDRESS",
+    "LD_LIBRARY_PATH",
+    "TERM",
+    "SHELL",
+  ]);
+
+  for (const key of safeKeys) {
+    if (process.env[key] !== undefined) safe[key] = process.env[key];
+  }
+
+  // AppImage-specific overrides
+  safe.ARCH = "x86_64";
+  safe.APPIMAGE_EXTRACT_AND_RUN = "1";
+
+  return safe;
+}
+
+/**
+ * Audit the sanitized env and reject if any known secret patterns leaked through.
+ *
+ * @param {Record<string, string>} env
+ */
+export function assertNoSecretsInEnv(env) {
+  for (const pattern of SECRET_ENV_PATTERNS) {
+    if (pattern in env) {
+      throw new Error(
+        `Refusing to pass secret-bearing env var "${pattern}" to appimagetool subprocess.`,
+      );
+    }
+  }
+}
+
 /**
  * Remove bundled libwayland-* libraries from a Linux AppImage.
  *
@@ -11,21 +89,28 @@ import { spawnSync } from "node:child_process";
  * system Mesa/EGL stack, causing a dynamic-loader symbol resolution error:
  *   /usr/lib/libEGL_mesa.so.0: undefined symbol: wl_fixes_interface
  *
- * This function extracts the AppImage, deletes the conflicting libraries, and
- * repacks the AppImage using appimagetool.
+ * This function extracts the AppImage, deletes the conflicting libraries,
+ * repacks the AppImage using appimagetool, and verifies the result.
  *
  * @param {string} appImagePath - Path to the .AppImage file to prune.
- * @param {string} [appimagetoolPath] - Path to appimagetool executable.
+ * @param {object} [options]
+ * @param {string} [options.appimagetoolPath] - Path to appimagetool executable.
  *   Defaults to the APPIMAGETOOL environment variable.
- * @returns {string} Path to the (possibly pruned) AppImage.
+ * @param {boolean} [options.failClosed=false] - When true, any failure or
+ *   unexpected condition (missing tool, no libraries found, extraction/repack
+ *   error) throws instead of silently returning the original path.
+ * @param {Function} [options.run] - Inject a custom spawn runner for testing.
+ *   Signature: (cmd: string, args: string[], opts?: object) => void.
+ * @returns {string} Path to the pruned AppImage.
  */
-export function pruneAppImageWaylandLibs(appImagePath, appimagetoolPath) {
+export function pruneAppImageWaylandLibs(appImagePath, options = {}) {
+  const { appimagetoolPath, failClosed = false, run: customRun } = options;
   const toolPath = appimagetoolPath || process.env.APPIMAGETOOL;
+
   if (!toolPath) {
-    console.warn(
-      "appimagetool not found (set APPIMAGETOOL env var or pass --appimagetool). "
-      + "Skipping AppImage Wayland library pruning.",
-    );
+    const msg = "appimagetool not found (set APPIMAGETOOL env var or pass options.appimagetoolPath).";
+    if (failClosed) throw new Error(msg);
+    console.warn(`${msg} Skipping AppImage Wayland library pruning.`);
     return appImagePath;
   }
 
@@ -33,76 +118,97 @@ export function pruneAppImageWaylandLibs(appImagePath, appimagetoolPath) {
   const appImageName = basename(appImagePath);
   const extractDir = join(cwd, `.appimage-prune-${process.pid}`);
 
-  function run(cmd, args, opts = {}) {
+  function defaultRun(cmd, args, opts = {}) {
     console.log(`> ${basename(cmd)} ${args.join(" ")}`);
     const result = spawnSync(cmd, args, { stdio: "inherit", ...opts });
     if (result.error) throw new Error(`${cmd} failed: ${result.error.message}`);
     if (result.status !== 0) throw new Error(`${cmd} exited with status ${result.status}.`);
   }
+  const run = customRun || defaultRun;
 
-  try {
-    // Create temp extraction directory
-    rmSync(extractDir, { recursive: true, force: true });
-    mkdirSync(extractDir, { recursive: true });
+  // Fail closed: all errors propagate instead of returning the original path.
+  rmSync(extractDir, { recursive: true, force: true });
+  mkdirSync(extractDir, { recursive: true });
 
-    // Extract AppImage
-    console.log(`Extracting AppImage: ${appImagePath}`);
-    run(appImagePath, ["--appimage-extract"], { cwd: extractDir });
+  // Extract AppImage
+  console.log(`Extracting AppImage: ${appImagePath}`);
+  run(appImagePath, ["--appimage-extract"], { cwd: extractDir });
 
-    const squashfsRoot = join(extractDir, "squashfs-root");
-    if (!existsSync(squashfsRoot)) {
-      throw new Error(`AppImage extraction did not produce squashfs-root in ${extractDir}`);
-    }
-
-    // Remove bundled libwayland-* libraries
-    const libDir = join(squashfsRoot, "usr", "lib");
-    let removedCount = 0;
-    if (existsSync(libDir)) {
-      const waylandLibs = readdirSync(libDir).filter((f) => f.startsWith("libwayland-"));
-      for (const lib of waylandLibs) {
-        const libPath = join(libDir, lib);
-        console.log(`Removing bundled library: ${libPath}`);
-        rmSync(libPath, { force: true });
-        removedCount++;
-      }
-    }
-
-    if (removedCount === 0) {
-      console.log("No bundled libwayland-* libraries found; nothing to prune.");
-      rmSync(extractDir, { recursive: true, force: true });
-      return appImagePath;
-    }
-
-    console.log(`Removed ${removedCount} bundled Wayland librar${removedCount === 1 ? "y" : "ies"}.`);
-
-    // Repack using appimagetool
-    const prunedPath = join(extractDir, appImageName);
-    console.log("Repacking AppImage with appimagetool...");
-    run(toolPath, [squashfsRoot, prunedPath], {
-      env: { ...process.env, ARCH: "x86_64", APPIMAGE_EXTRACT_AND_RUN: "1" },
-    });
-
-    // Backup original and replace with pruned
-    const backupPath = `${appImagePath}.wayland-backup`;
-    rmSync(backupPath, { force: true });
-    console.log(`Replacing original AppImage with pruned version`);
-    renameSync(appImagePath, backupPath);
-    try {
-      renameSync(prunedPath, appImagePath);
-    } catch (err) {
-      // Restore original on failure
-      renameSync(backupPath, appImagePath);
-      throw err;
-    }
-    rmSync(backupPath, { force: true });
-
-    console.log("AppImage Wayland library pruning complete.");
-    return appImagePath;
-  } catch (error) {
-    console.warn(`AppImage Wayland library pruning failed: ${error.message}`);
-    console.warn("Falling back to the unpruned AppImage.");
-    return appImagePath;
-  } finally {
-    rmSync(extractDir, { recursive: true, force: true });
+  const squashfsRoot = join(extractDir, "squashfs-root");
+  if (!existsSync(squashfsRoot)) {
+    throw new Error(`AppImage extraction did not produce squashfs-root in ${extractDir}`);
   }
+
+  // Remove bundled libwayland-* libraries
+  const libDir = join(squashfsRoot, "usr", "lib");
+  let removedCount = 0;
+  const removedLibs = [];
+  if (existsSync(libDir)) {
+    const waylandLibs = readdirSync(libDir).filter((f) => f.startsWith("libwayland-"));
+    for (const lib of waylandLibs) {
+      const libPath = join(libDir, lib);
+      console.log(`Removing bundled library: ${libPath}`);
+      rmSync(libPath, { force: true });
+      removedLibs.push(lib);
+      removedCount++;
+    }
+  }
+
+  if (removedCount === 0) {
+    const msg = "No bundled libwayland-* libraries found; nothing to prune.";
+    if (failClosed) throw new Error(msg);
+    console.log(msg);
+    rmSync(extractDir, { recursive: true, force: true });
+    return appImagePath;
+  }
+
+  console.log(
+    `Removed ${removedCount} bundled Wayland librar${removedCount === 1 ? "y" : "ies"}: ${removedLibs.join(", ")}.`,
+  );
+
+  // Repack using appimagetool with sanitized environment (no secrets)
+  const prunedPath = join(extractDir, appImageName);
+  const subprocessEnv = sanitizedEnv();
+  assertNoSecretsInEnv(subprocessEnv);
+  console.log("Repacking AppImage with appimagetool...");
+  run(toolPath, [squashfsRoot, prunedPath], { env: subprocessEnv });
+
+  // Verify the pruned AppImage contains no libwayland-* libraries
+  console.log("Verifying pruned AppImage has no bundled Wayland libraries...");
+  const verifyDir = join(extractDir, "verify");
+  mkdirSync(verifyDir, { recursive: true });
+  run(prunedPath, ["--appimage-extract"], { cwd: verifyDir, env: subprocessEnv });
+  const verifySquashfs = join(verifyDir, "squashfs-root");
+  if (!existsSync(verifySquashfs)) {
+    throw new Error("Verification extraction did not produce squashfs-root.");
+  }
+  const verifyLibDir = join(verifySquashfs, "usr", "lib");
+  if (existsSync(verifyLibDir)) {
+    const remainingLibs = readdirSync(verifyLibDir).filter((f) => f.startsWith("libwayland-"));
+    if (remainingLibs.length > 0) {
+      throw new Error(
+        `Pruned AppImage still contains bundled Wayland libraries: ${remainingLibs.join(", ")}. ` +
+        "Pruning was ineffective — refusing to publish.",
+      );
+    }
+  }
+  rmSync(verifyDir, { recursive: true, force: true });
+  console.log("Verification passed: no libwayland-* libraries remain in the pruned AppImage.");
+
+  // Backup original and replace with pruned
+  const backupPath = `${appImagePath}.wayland-backup`;
+  rmSync(backupPath, { force: true });
+  console.log("Replacing original AppImage with pruned version");
+  renameSync(appImagePath, backupPath);
+  try {
+    renameSync(prunedPath, appImagePath);
+  } catch (err) {
+    // Restore original on replacement failure
+    renameSync(backupPath, appImagePath);
+    throw err;
+  }
+  rmSync(backupPath, { force: true });
+
+  console.log("AppImage Wayland library pruning complete.");
+  return appImagePath;
 }

--- a/scripts/prune-appimage-wayland-libs.mjs
+++ b/scripts/prune-appimage-wayland-libs.mjs
@@ -1,0 +1,108 @@
+import { existsSync, mkdirSync, readdirSync, rmSync, renameSync } from "node:fs";
+import { basename, join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+/**
+ * Remove bundled libwayland-* libraries from a Linux AppImage.
+ *
+ * The AppImage produced by Tauri bundles libwayland-client, libwayland-cursor,
+ * and libwayland-egl from the build host (typically Ubuntu). On Arch Linux and
+ * other rolling-release distributions these bundled libraries conflict with the
+ * system Mesa/EGL stack, causing a dynamic-loader symbol resolution error:
+ *   /usr/lib/libEGL_mesa.so.0: undefined symbol: wl_fixes_interface
+ *
+ * This function extracts the AppImage, deletes the conflicting libraries, and
+ * repacks the AppImage using appimagetool.
+ *
+ * @param {string} appImagePath - Path to the .AppImage file to prune.
+ * @param {string} [appimagetoolPath] - Path to appimagetool executable.
+ *   Defaults to the APPIMAGETOOL environment variable.
+ * @returns {string} Path to the (possibly pruned) AppImage.
+ */
+export function pruneAppImageWaylandLibs(appImagePath, appimagetoolPath) {
+  const toolPath = appimagetoolPath || process.env.APPIMAGETOOL;
+  if (!toolPath) {
+    console.warn(
+      "appimagetool not found (set APPIMAGETOOL env var or pass --appimagetool). "
+      + "Skipping AppImage Wayland library pruning.",
+    );
+    return appImagePath;
+  }
+
+  const cwd = process.cwd();
+  const appImageName = basename(appImagePath);
+  const extractDir = join(cwd, `.appimage-prune-${process.pid}`);
+
+  function run(cmd, args, opts = {}) {
+    console.log(`> ${basename(cmd)} ${args.join(" ")}`);
+    const result = spawnSync(cmd, args, { stdio: "inherit", ...opts });
+    if (result.error) throw new Error(`${cmd} failed: ${result.error.message}`);
+    if (result.status !== 0) throw new Error(`${cmd} exited with status ${result.status}.`);
+  }
+
+  try {
+    // Create temp extraction directory
+    rmSync(extractDir, { recursive: true, force: true });
+    mkdirSync(extractDir, { recursive: true });
+
+    // Extract AppImage
+    console.log(`Extracting AppImage: ${appImagePath}`);
+    run(appImagePath, ["--appimage-extract"], { cwd: extractDir });
+
+    const squashfsRoot = join(extractDir, "squashfs-root");
+    if (!existsSync(squashfsRoot)) {
+      throw new Error(`AppImage extraction did not produce squashfs-root in ${extractDir}`);
+    }
+
+    // Remove bundled libwayland-* libraries
+    const libDir = join(squashfsRoot, "usr", "lib");
+    let removedCount = 0;
+    if (existsSync(libDir)) {
+      const waylandLibs = readdirSync(libDir).filter((f) => f.startsWith("libwayland-"));
+      for (const lib of waylandLibs) {
+        const libPath = join(libDir, lib);
+        console.log(`Removing bundled library: ${libPath}`);
+        rmSync(libPath, { force: true });
+        removedCount++;
+      }
+    }
+
+    if (removedCount === 0) {
+      console.log("No bundled libwayland-* libraries found; nothing to prune.");
+      rmSync(extractDir, { recursive: true, force: true });
+      return appImagePath;
+    }
+
+    console.log(`Removed ${removedCount} bundled Wayland librar${removedCount === 1 ? "y" : "ies"}.`);
+
+    // Repack using appimagetool
+    const prunedPath = join(extractDir, appImageName);
+    console.log("Repacking AppImage with appimagetool...");
+    run(toolPath, [squashfsRoot, prunedPath], {
+      env: { ...process.env, ARCH: "x86_64", APPIMAGE_EXTRACT_AND_RUN: "1" },
+    });
+
+    // Backup original and replace with pruned
+    const backupPath = `${appImagePath}.wayland-backup`;
+    rmSync(backupPath, { force: true });
+    console.log(`Replacing original AppImage with pruned version`);
+    renameSync(appImagePath, backupPath);
+    try {
+      renameSync(prunedPath, appImagePath);
+    } catch (err) {
+      // Restore original on failure
+      renameSync(backupPath, appImagePath);
+      throw err;
+    }
+    rmSync(backupPath, { force: true });
+
+    console.log("AppImage Wayland library pruning complete.");
+    return appImagePath;
+  } catch (error) {
+    console.warn(`AppImage Wayland library pruning failed: ${error.message}`);
+    console.warn("Falling back to the unpruned AppImage.");
+    return appImagePath;
+  } finally {
+    rmSync(extractDir, { recursive: true, force: true });
+  }
+}

--- a/scripts/prune-appimage-wayland-libs.test.mjs
+++ b/scripts/prune-appimage-wayland-libs.test.mjs
@@ -1,0 +1,411 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+  sanitizedEnv,
+  assertNoSecretsInEnv,
+  SECRET_ENV_PATTERNS,
+  pruneAppImageWaylandLibs,
+} from "./prune-appimage-wayland-libs.mjs";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tmpDir() {
+  const dir = join(process.cwd(), `.prune-test-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// sanitizedEnv / assertNoSecretsInEnv
+// ---------------------------------------------------------------------------
+
+describe("sanitizedEnv", () => {
+  it("includes standard safe variables from process.env", () => {
+    const env = sanitizedEnv();
+    assert.ok(typeof env.PATH === "string" || env.PATH === undefined,
+      "PATH should be present if defined in process.env");
+  });
+
+  it("always includes ARCH and APPIMAGE_EXTRACT_AND_RUN", () => {
+    const env = sanitizedEnv();
+    assert.strictEqual(env.ARCH, "x86_64");
+    assert.strictEqual(env.APPIMAGE_EXTRACT_AND_RUN, "1");
+  });
+
+  it("never includes known secret patterns", () => {
+    for (const pattern of SECRET_ENV_PATTERNS) {
+      const env = sanitizedEnv();
+      assert.ok(!(pattern in env),
+        `sanitizedEnv must not include ${pattern}`);
+    }
+  });
+
+  it("does not include unrecognized env vars", () => {
+    process.env.OCG_PRUNE_TEST_XYZ = "test-value";
+    try {
+      const env = sanitizedEnv();
+      assert.ok(!("OCG_PRUNE_TEST_XYZ" in env),
+        "unrecognized vars must not leak into sanitized env");
+    } finally {
+      delete process.env.OCG_PRUNE_TEST_XYZ;
+    }
+  });
+
+  it("assertNoSecretsInEnv throws for each known secret", () => {
+    for (const pattern of SECRET_ENV_PATTERNS) {
+      assert.throws(
+        () => assertNoSecretsInEnv({ [pattern]: "leaked" }),
+        new RegExp(pattern),
+      );
+    }
+  });
+
+  it("assertNoSecretsInEnv passes for clean env", () => {
+    assertNoSecretsInEnv({ PATH: "/usr/bin", HOME: "/home/user", ARCH: "x86_64" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pruneAppImageWaylandLibs
+// ---------------------------------------------------------------------------
+
+describe("pruneAppImageWaylandLibs", () => {
+  let runCalls;
+  let capturedRunEnv;
+  let runShouldThrow;
+  let runSkipRepackOutput;
+
+  /**
+   * Build a mock `run` that simulates the expected side-effects of each call:
+   *
+   *   call 1 — extract: create squashfs-root/usr/lib with `waylandLibs`
+   *   call 2 — repack:  create the pruned output file, capture env
+   *   call 3 — verify:  create squashfs-root/usr/lib with `verificationLibs`
+   *                      (null = empty, no libwayland-*)
+   *
+   * @param {object} opts
+   * @param {string[]} [opts.waylandLibs] — libs present in the extracted AppImage
+   * @param {string[]|null} [opts.verificationLibs] — libs present after repack
+   */
+  function mockRunFactory({ waylandLibs = [], verificationLibs = null } = {}) {
+    let count = 0;
+    return (cmd, args, runOpts = {}) => {
+      count++;
+      runCalls.push({ count, cmd, args, opts: { ...runOpts } });
+      if (runOpts.env) capturedRunEnv = { ...runOpts.env };
+
+      if (runShouldThrow) {
+        throw new Error("mock run threw");
+      }
+
+      if (count === 1) {
+        // Extraction — create squashfs-root at the cwd the function gave us.
+        const extractCwd = runOpts.cwd;
+        if (extractCwd) {
+          const libDir = join(extractCwd, "squashfs-root", "usr", "lib");
+          mkdirSync(libDir, { recursive: true });
+          for (const lib of waylandLibs) {
+            writeFileSync(join(libDir, lib), "");
+          }
+        }
+      }
+
+      if (count === 2 && !runSkipRepackOutput) {
+        // Repack — create the output file so rename can proceed.
+        const outputPath = args[1];
+        if (outputPath) writeFileSync(outputPath, "mock-pruned-appimage");
+      }
+
+      if (count === 3) {
+        // Verification extraction.
+        const cwd = runOpts.cwd || process.cwd();
+        const verifyLibDir = join(cwd, "squashfs-root", "usr", "lib");
+        mkdirSync(verifyLibDir, { recursive: true });
+        if (verificationLibs) {
+          for (const lib of verificationLibs) {
+            writeFileSync(join(verifyLibDir, lib), "");
+          }
+        }
+      }
+    };
+  }
+
+  beforeEach(() => {
+    runCalls = [];
+    capturedRunEnv = null;
+    runShouldThrow = false;
+    runSkipRepackOutput = false;
+  });
+
+  // -- failClosed: missing tool ---------------------------------------------
+
+  it("throws when appimagetool is missing and failClosed is true", () => {
+    assert.throws(
+      () => pruneAppImageWaylandLibs("/fake/appimage", {
+        failClosed: true,
+        appimagetoolPath: "",
+      }),
+      /appimagetool not found/,
+    );
+  });
+
+  it("returns original path when appimagetool is missing and failClosed is false", () => {
+    const result = pruneAppImageWaylandLibs("/fake/appimage", {
+      failClosed: false,
+      appimagetoolPath: "",
+    });
+    assert.strictEqual(result, "/fake/appimage");
+  });
+
+  // -- failClosed: no libraries found ---------------------------------------
+
+  it("throws when no libwayland-* are found and failClosed is true", () => {
+    const dir = tmpDir();
+    const appImage = join(dir, "test.AppImage");
+    writeFileSync(appImage, "mock-appimage");
+
+    try {
+      assert.throws(
+        () => pruneAppImageWaylandLibs(appImage, {
+          failClosed: true,
+          appimagetoolPath: "/fake/appimagetool",
+          run: mockRunFactory({ waylandLibs: [] }),
+        }),
+        /No bundled libwayland-/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns original path when no libwayland-* are found and failClosed is false", () => {
+    const dir = tmpDir();
+    const appImage = join(dir, "test.AppImage");
+    writeFileSync(appImage, "mock-appimage");
+
+    try {
+      const result = pruneAppImageWaylandLibs(appImage, {
+        failClosed: false,
+        appimagetoolPath: "/fake/appimagetool",
+        run: mockRunFactory({ waylandLibs: [] }),
+      });
+      assert.strictEqual(result, appImage);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // -- success path ---------------------------------------------------------
+
+  it("successfully prunes, verifies, and replaces the AppImage", () => {
+    const dir = tmpDir();
+    const appImage = join(dir, "test.AppImage");
+    writeFileSync(appImage, "original-content");
+
+    try {
+      const result = pruneAppImageWaylandLibs(appImage, {
+        failClosed: true,
+        appimagetoolPath: "/fake/appimagetool",
+        run: mockRunFactory({
+          waylandLibs: ["libwayland-client.so.0", "libwayland-egl.so.1"],
+        }),
+      });
+
+      assert.strictEqual(result, appImage);
+      assert.ok(existsSync(appImage), "pruned AppImage should exist at original path");
+      assert.ok(!existsSync(`${appImage}.wayland-backup`), "backup should be removed");
+      assert.strictEqual(runCalls.length, 3,
+        `expected 3 run calls (extract, repack, verify), got ${runCalls.length}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // -- extraction failure ---------------------------------------------------
+
+  it("throws when extraction does not produce squashfs-root", () => {
+    const dir = tmpDir();
+    const appImage = join(dir, "test.AppImage");
+    writeFileSync(appImage, "mock-appimage");
+
+    // A mock that does NOT create squashfs-root on call 1.
+    let count = 0;
+    const noExtractRun = (cmd, args, runOpts) => { count++; };
+
+    try {
+      assert.throws(
+        () => pruneAppImageWaylandLibs(appImage, {
+          failClosed: true,
+          appimagetoolPath: "/fake/appimagetool",
+          run: noExtractRun,
+        }),
+        /did not produce squashfs-root/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // -- repack failure -------------------------------------------------------
+
+  it("throws when the run function throws", () => {
+    const dir = tmpDir();
+    const appImage = join(dir, "test.AppImage");
+    writeFileSync(appImage, "original-content");
+    runShouldThrow = true;
+
+    try {
+      assert.throws(
+        () => pruneAppImageWaylandLibs(appImage, {
+          failClosed: true,
+          appimagetoolPath: "/fake/appimagetool",
+          run: mockRunFactory({
+            waylandLibs: ["libwayland-client.so.0"],
+          }),
+        }),
+      );
+      assert.ok(existsSync(appImage),
+        "original AppImage should be preserved on failure");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // -- post-pruning verification --------------------------------------------
+
+  it("throws when verification finds remaining libwayland-* libraries", () => {
+    const dir = tmpDir();
+    const appImage = join(dir, "test.AppImage");
+    writeFileSync(appImage, "original-content");
+
+    try {
+      assert.throws(
+        () => pruneAppImageWaylandLibs(appImage, {
+          failClosed: true,
+          appimagetoolPath: "/fake/appimagetool",
+          run: mockRunFactory({
+            waylandLibs: ["libwayland-client.so.0"],
+            verificationLibs: ["libwayland-client.so.0"],
+          }),
+        }),
+        /still contains bundled Wayland libraries/,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("succeeds when verification finds no remaining libwayland-*", () => {
+    const dir = tmpDir();
+    const appImage = join(dir, "test.AppImage");
+    writeFileSync(appImage, "original-content");
+
+    try {
+      const result = pruneAppImageWaylandLibs(appImage, {
+        failClosed: true,
+        appimagetoolPath: "/fake/appimagetool",
+        run: mockRunFactory({
+          waylandLibs: ["libwayland-client.so.0"],
+        }),
+      });
+      assert.strictEqual(result, appImage);
+      assert.strictEqual(runCalls.length, 3);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // -- env sanitization -----------------------------------------------------
+
+  it("does not pass secrets to the appimagetool subprocess", () => {
+    const dir = tmpDir();
+    const appImage = join(dir, "test.AppImage");
+    writeFileSync(appImage, "original-content");
+
+    const saved = {};
+    for (const pattern of SECRET_ENV_PATTERNS) {
+      saved[pattern] = process.env[pattern];
+      process.env[pattern] = `fake-${pattern}`;
+    }
+
+    try {
+      pruneAppImageWaylandLibs(appImage, {
+        failClosed: true,
+        appimagetoolPath: "/fake/appimagetool",
+        run: mockRunFactory({
+          waylandLibs: ["libwayland-client.so.0"],
+        }),
+      });
+
+      assert.ok(capturedRunEnv, "should have captured run env from repack call");
+      for (const pattern of SECRET_ENV_PATTERNS) {
+        assert.ok(!(pattern in capturedRunEnv),
+          `captured env must not contain ${pattern}`);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      for (const pattern of SECRET_ENV_PATTERNS) {
+        if (saved[pattern] === undefined) {
+          delete process.env[pattern];
+        } else {
+          process.env[pattern] = saved[pattern];
+        }
+      }
+    }
+  });
+
+  it("repack env contains required AppImage vars", () => {
+    const dir = tmpDir();
+    const appImage = join(dir, "test.AppImage");
+    writeFileSync(appImage, "original-content");
+
+    try {
+      pruneAppImageWaylandLibs(appImage, {
+        failClosed: true,
+        appimagetoolPath: "/fake/appimagetool",
+        run: mockRunFactory({
+          waylandLibs: ["libwayland-client.so.0"],
+        }),
+      });
+
+      assert.ok(capturedRunEnv, "should have captured run env");
+      assert.strictEqual(capturedRunEnv.ARCH, "x86_64");
+      assert.strictEqual(capturedRunEnv.APPIMAGE_EXTRACT_AND_RUN, "1");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // -- rollback on replacement failure --------------------------------------
+
+  it("rolls back when replacement rename fails", () => {
+    const dir = tmpDir();
+    const appImage = join(dir, "test.AppImage");
+    writeFileSync(appImage, "original-content");
+    runSkipRepackOutput = true;
+
+    try {
+      assert.throws(
+        () => pruneAppImageWaylandLibs(appImage, {
+          failClosed: true,
+          appimagetoolPath: "/fake/appimagetool",
+          run: mockRunFactory({
+            waylandLibs: ["libwayland-client.so.0"],
+          }),
+        }),
+      );
+      // Original should be preserved, backup cleaned
+      assert.ok(existsSync(appImage),
+        "original AppImage should be preserved on rename failure");
+      assert.ok(!existsSync(`${appImage}.wayland-backup`),
+        "backup should be cleaned on rename failure");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -21,6 +21,7 @@ import {
   verifyUpdaterPublicKeyContinuity,
   verifyUpdaterSignature,
 } from "./generate-updater-manifest.mjs";
+import { pruneAppImageWaylandLibs } from "./prune-appimage-wayland-libs.mjs";
 import { validateComposeVersion } from "./release-policy.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -321,11 +322,16 @@ async function main() {
       ...buildConfigArgs,
     ], { env: tauriBuildEnvironment });
     const appImage = onlyArtifact(join(bundleRoot, "appimage"), ".AppImage", "AppImage");
+    const prunedAppImage = pruneAppImageWaylandLibs(appImage);
     const appImageName = `ocg-manager_${version}_linux-x64.AppImage`;
     if (updaterPlan.enabled) {
-      stageUpdaterArtifact(appImage, appImageName, artifacts, updaterPlan.publicKey);
+      rmSync(`${prunedAppImage}.sig`, { force: true });
+      run(process.execPath, [tauriCli, "signer", "sign", prunedAppImage], {
+        env: resolveFileSignerEnvironment(),
+      });
+      stageUpdaterArtifact(prunedAppImage, appImageName, artifacts, updaterPlan.publicKey);
     }
-    else stageArtifact(appImage, appImageName, artifacts);
+    else stageArtifact(prunedAppImage, appImageName, artifacts);
 
     const deb = onlyArtifact(join(bundleRoot, "deb"), ".deb", "deb package");
     const debName = `ocg-manager_${version}_linux-x64.deb`;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -322,7 +322,7 @@ async function main() {
       ...buildConfigArgs,
     ], { env: tauriBuildEnvironment });
     const appImage = onlyArtifact(join(bundleRoot, "appimage"), ".AppImage", "AppImage");
-    const prunedAppImage = pruneAppImageWaylandLibs(appImage);
+    const prunedAppImage = pruneAppImageWaylandLibs(appImage, { failClosed: true });
     const appImageName = `ocg-manager_${version}_linux-x64.AppImage`;
     if (updaterPlan.enabled) {
       rmSync(`${prunedAppImage}.sig`, { force: true });


### PR DESCRIPTION
该 PR 修复了当前应用在 Arch 系 Linux 无法正确运行的问题，该问题表现为应用启动后崩溃，控制台输出：
```fish
Could not create surfaceless EGL display: EGL_BAD_ALLOC. Aborting...
```
该问题为 Tauri 应用共有问题，原因为 AppImage 内的 libwayland 与系统库不兼容。本 PR 解决方案为在 AppImage 构建完成后移除捆绑的wayland有关库，从而解决此问题