### PR TITLE
release: prepare v1.6.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@ OCG_PORT=9042
 # Recommended for production: pin an exact release. Use latest only for intentional rolling upgrades.
 # Set ocg-manager:local and ocg-manager-browser:local instead when building the
 # current checkout from source with the optional browser profile.
-# OCG_IMAGE=ghcr.io/klarkxy/opencode-go-mgr:1.6.0
-# OCG_BROWSER_IMAGE=ghcr.io/klarkxy/opencode-go-mgr-browser:1.6.0
+# OCG_IMAGE=ghcr.io/klarkxy/opencode-go-mgr:1.6.1
+# OCG_BROWSER_IMAGE=ghcr.io/klarkxy/opencode-go-mgr-browser:1.6.1
 # Optional first-start bootstrap. Uncomment both and replace the password, or leave both unset
 # so the first dashboard visitor creates the administrator. Remove them after initialization.
 # OCG_ADMIN_USERNAME=admin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "ocg-browser-worker"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "ocg-core"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "ocg-manager"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "ocg-manager-cli"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.6.0"
+version = "1.6.1"
 edition = "2024"
 authors = ["ocg-manager"]
 license-file = "LICENSE"

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -1,9 +1,9 @@
-# Pull-only Docker Compose example for OCG Manager v1.6.0.
+# Pull-only Docker Compose example for OCG Manager v1.6.1.
 # Save this file as compose.yaml. Optionally create a neighboring .env file
 # with OCG_PORT, OCG_IMAGE, OCG_BROWSER_IMAGE, or the runtime variables below.
 services:
   ocg-manager:
-    image: ${OCG_IMAGE:-ghcr.io/klarkxy/opencode-go-mgr:1.6.0}
+    image: ${OCG_IMAGE:-ghcr.io/klarkxy/opencode-go-mgr:1.6.1}
     platform: linux/amd64
     restart: unless-stopped
     environment:
@@ -40,7 +40,7 @@ services:
   # Reserve at least 2 CPU, 2 GiB RAM, and 1 GiB shared memory on the host.
   browser:
     profiles: ["browser"]
-    image: ${OCG_BROWSER_IMAGE:-ghcr.io/klarkxy/opencode-go-mgr-browser:1.6.0}
+    image: ${OCG_BROWSER_IMAGE:-ghcr.io/klarkxy/opencode-go-mgr-browser:1.6.1}
     platform: linux/amd64
     restart: unless-stopped
     environment:

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,11 +46,11 @@ When docs disagree, prefer the source below and fix the other side.
 | Agent coding constraints / 助手约束 | [../AGENTS.md](../AGENTS.md) |
 
 Example version in Docker snippets should match the current release line
-(currently **v1.6.0**). Do not leave older patch pins in USER /
+(currently **v1.6.1**). Do not leave older patch pins in USER /
 `.env.example` / `compose.example.yaml` after a version bump. The product
 README no longer pins a clone tag.
 
-Docker 示例里的版本钉应与当前发版线一致（现为 **v1.6.0**）。升版后不要把
+Docker 示例里的版本钉应与当前发版线一致（现为 **v1.6.1**）。升版后不要把
 USER / `.env.example` / `compose.example.yaml` 留在旧 patch。产品 README
 不再钉 clone tag。
 

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -914,7 +914,7 @@ checkout containing `compose.yaml` and `.env.example` (preferably the
 matching release tag):
 
 ```bash
-git clone --branch v1.6.0 --depth 1 https://github.com/klarkxy/opencode-go-mgr.git
+git clone --branch v1.6.1 --depth 1 https://github.com/klarkxy/opencode-go-mgr.git
 cd opencode-go-mgr
 cp .env.example .env
 # PowerShell: Copy-Item .env.example .env
@@ -930,7 +930,7 @@ docker compose ps
   `ghcr.io/klarkxy/opencode-go-mgr:latest`; the Release
   `compose.example.yaml` defaults to its matching full version.
 - For repeatable production deployments, set `OCG_IMAGE` in `.env` to a full
-  release tag such as `ghcr.io/klarkxy/opencode-go-mgr:1.6.0`.
+  release tag such as `ghcr.io/klarkxy/opencode-go-mgr:1.6.1`.
 - Full-version and `sha-<commit>` tags identify one release and are intended
   not to move; `1.5` and `latest` move forward. Only a digest such as
   `ghcr.io/klarkxy/opencode-go-mgr@sha256:...` is technically immutable.
@@ -1077,13 +1077,13 @@ provenance, and a GitHub signed provenance attestation. Inspect and verify a
 release with:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/klarkxy/opencode-go-mgr:1.6.0
-docker buildx imagetools inspect ghcr.io/klarkxy/opencode-go-mgr-browser:1.6.0
+docker buildx imagetools inspect ghcr.io/klarkxy/opencode-go-mgr:1.6.1
+docker buildx imagetools inspect ghcr.io/klarkxy/opencode-go-mgr-browser:1.6.1
 gh attestation verify \
-  oci://ghcr.io/klarkxy/opencode-go-mgr:1.6.0 \
+  oci://ghcr.io/klarkxy/opencode-go-mgr:1.6.1 \
   --repo klarkxy/opencode-go-mgr
 gh attestation verify \
-  oci://ghcr.io/klarkxy/opencode-go-mgr-browser:1.6.0 \
+  oci://ghcr.io/klarkxy/opencode-go-mgr-browser:1.6.1 \
   --repo klarkxy/opencode-go-mgr
 ```
 

--- a/docs/USER.zh-CN.md
+++ b/docs/USER.zh-CN.md
@@ -764,7 +764,7 @@ GHCR 上的公开无头镜像无需登录即可拉取。它是 Linux 容器，�
 与 `.env.example` 的仓库目录中运行（建议检出对应 Release tag）：
 
 ```bash
-git clone --branch v1.6.0 --depth 1 https://github.com/klarkxy/opencode-go-mgr.git
+git clone --branch v1.6.1 --depth 1 https://github.com/klarkxy/opencode-go-mgr.git
 cd opencode-go-mgr
 cp .env.example .env
 # PowerShell：Copy-Item .env.example .env
@@ -780,7 +780,7 @@ docker compose ps
   `ghcr.io/klarkxy/opencode-go-mgr:latest`；Release 中的 `compose.example.yaml`
   默认固定对应的完整版本。
 - 生产部署建议在 `.env` 中用 `OCG_IMAGE` 固定完整版本标签，例如
-  `ghcr.io/klarkxy/opencode-go-mgr:1.6.0`。
+  `ghcr.io/klarkxy/opencode-go-mgr:1.6.1`。
 - 完整版本与 `sha-<commit>` 标签用于标识单次发布，按发布策略不应移动；`1.5`
   与 `latest` 会继续移动。技术上只有
   `ghcr.io/klarkxy/opencode-go-mgr@sha256:...` digest 真正不可变。
@@ -901,13 +901,13 @@ curl --fail http://127.0.0.1:9042/dashboard/
 provenance attestation。可这样检查发布版本：
 
 ```bash
-docker buildx imagetools inspect ghcr.io/klarkxy/opencode-go-mgr:1.6.0
-docker buildx imagetools inspect ghcr.io/klarkxy/opencode-go-mgr-browser:1.6.0
+docker buildx imagetools inspect ghcr.io/klarkxy/opencode-go-mgr:1.6.1
+docker buildx imagetools inspect ghcr.io/klarkxy/opencode-go-mgr-browser:1.6.1
 gh attestation verify \
-  oci://ghcr.io/klarkxy/opencode-go-mgr:1.6.0 \
+  oci://ghcr.io/klarkxy/opencode-go-mgr:1.6.1 \
   --repo klarkxy/opencode-go-mgr
 gh attestation verify \
-  oci://ghcr.io/klarkxy/opencode-go-mgr-browser:1.6.0 \
+  oci://ghcr.io/klarkxy/opencode-go-mgr-browser:1.6.1 \
   --repo klarkxy/opencode-go-mgr
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ocg-manager-ui",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "packageManager": "pnpm@10.29.2",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocg-manager"
-version = "1.6.0"
+version = "1.6.1"
 description = "OpenCode-Go multi-account key manager"
 authors = ["ocg-manager"]
 license-file = "../LICENSE"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
   },
   "identifier": "com.klarkxy.ocgmanager",
   "productName": "OCG Manager",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "app": {
     "security": {
       "csp": "default-src 'self'; connect-src 'self' http://localhost:9042; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'",


### PR DESCRIPTION
No remaining feature PRs. This prepares **v1.6.1** after #38 and #39 landed on `main`.

- Bump `package.json`, workspace `Cargo.toml`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `compose.example.yaml`, `.env.example`, USER Docker pins, and `docs/README.md`
- Refresh `Cargo.lock` workspace package versions
- Local `pnpm run test`, `design:lint`, and `release:check` passed for v1.6.1

After merge, tag `v1.6.1` on the merge commit so the signed three-platform release workflow can run.