### PR TITLE
ci: publish linux/amd64 and linux/arm64 container images

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -27,14 +27,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build and verify GHCR images
+  resolve:
+    name: Resolve release metadata
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    timeout-minutes: 15
     outputs:
-      browser_digest: ${{ steps.push_browser.outputs.digest }}
       browser_image: ${{ steps.release.outputs.browser_image }}
-      digest: ${{ steps.push.outputs.digest }}
       full_sha: ${{ steps.commit.outputs.full_sha }}
       image: ${{ steps.release.outputs.image }}
       minor: ${{ steps.release.outputs.minor }}
@@ -45,17 +43,6 @@ jobs:
       version: ${{ steps.release.outputs.version }}
     permissions:
       contents: read
-      packages: write
-      attestations: write
-      id-token: write
-    env:
-      SMOKE_BROWSER_CONTAINER: ocg-browser-smoke-${{ github.run_id }}
-      SMOKE_BROWSER_IMAGE: ocg-browser:smoke-${{ github.run_id }}
-      SMOKE_BROWSER_PROFILE_VOLUME: ocg-browser-profile-smoke-${{ github.run_id }}
-      SMOKE_BROWSER_RUNTIME_VOLUME: ocg-browser-runtime-smoke-${{ github.run_id }}
-      SMOKE_IMAGE: ocg-manager:smoke-${{ github.run_id }}
-      SMOKE_CONTAINER: ocg-manager-smoke-${{ github.run_id }}
-      SMOKE_VOLUME: ocg-manager-smoke-${{ github.run_id }}
 
     steps:
       - name: Resolve release
@@ -139,6 +126,44 @@ jobs:
           echo "full_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "short_sha=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
 
+  build:
+    name: Build and verify GHCR images (${{ matrix.arch }})
+    needs: resolve
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 120
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runs-on: ubuntu-24.04
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
+    outputs:
+      browser_digest_amd64: ${{ steps.record_amd64.outputs.browser_digest }}
+      browser_digest_arm64: ${{ steps.record_arm64.outputs.browser_digest }}
+      digest_amd64: ${{ steps.record_amd64.outputs.digest }}
+      digest_arm64: ${{ steps.record_arm64.outputs.digest }}
+    permissions:
+      contents: read
+      packages: write
+    env:
+      SMOKE_BROWSER_CONTAINER: ocg-browser-smoke-${{ github.run_id }}-${{ matrix.arch }}
+      SMOKE_BROWSER_IMAGE: ocg-browser:smoke-${{ github.run_id }}-${{ matrix.arch }}
+      SMOKE_BROWSER_PROFILE_VOLUME: ocg-browser-profile-smoke-${{ github.run_id }}-${{ matrix.arch }}
+      SMOKE_BROWSER_RUNTIME_VOLUME: ocg-browser-runtime-smoke-${{ github.run_id }}-${{ matrix.arch }}
+      SMOKE_IMAGE: ocg-manager:smoke-${{ github.run_id }}-${{ matrix.arch }}
+      SMOKE_CONTAINER: ocg-manager-smoke-${{ github.run_id }}-${{ matrix.arch }}
+      SMOKE_VOLUME: ocg-manager-smoke-${{ github.run_id }}-${{ matrix.arch }}
+
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Same ref policy as the resolve job; both architecture legs build the identical commit.
+          ref: ${{ inputs.source_ref != '' && inputs.source_ref || format('refs/tags/{0}', needs.resolve.outputs.tag) }}
+          persist-credentials: false
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
@@ -154,6 +179,8 @@ jobs:
           vars: |
             SMOKE_IMAGE=${{ env.SMOKE_IMAGE }}
             SMOKE_BROWSER_IMAGE=${{ env.SMOKE_BROWSER_IMAGE }}
+            CACHE_SCOPE=ocg-manager-linux-${{ matrix.arch }}
+            CACHE_BROWSER_SCOPE=ocg-browser-linux-${{ matrix.arch }}
 
       - name: Smoke-test container
         shell: bash
@@ -328,29 +355,29 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ${{ steps.release.outputs.image }}
+          images: ${{ needs.resolve.outputs.image }}
           flavor: latest=false
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.release.outputs.tag }}
+            type=semver,pattern={{version}},value=${{ needs.resolve.outputs.tag }}
           labels: |
             org.opencontainers.image.title=OCG Manager
             org.opencontainers.image.description=OpenCode-Go multi-account local manager and gateway
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ steps.commit.outputs.full_sha }}
+            org.opencontainers.image.revision=${{ needs.resolve.outputs.full_sha }}
 
       - name: Generate browser image metadata
         id: meta_browser
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ${{ steps.release.outputs.browser_image }}
+          images: ${{ needs.resolve.outputs.browser_image }}
           flavor: latest=false
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.release.outputs.tag }}
+            type=semver,pattern={{version}},value=${{ needs.resolve.outputs.tag }}
           labels: |
             org.opencontainers.image.title=OCG Manager Browser Worker
             org.opencontainers.image.description=Isolated Chromium and noVNC sidecar for OCG Manager
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ steps.commit.outputs.full_sha }}
+            org.opencontainers.image.revision=${{ needs.resolve.outputs.full_sha }}
 
       - name: Build and push image
         id: push
@@ -358,14 +385,14 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
-          outputs: type=image,name=${{ steps.release.outputs.image }},push=true,push-by-digest=true,name-canonical=true
+          platforms: linux/${{ matrix.arch }}
+          outputs: type=image,name=${{ needs.resolve.outputs.image }},push=true,push-by-digest=true,name-canonical=true,oci-mediatypes=true
           labels: ${{ steps.meta.outputs.labels }}
           annotations: |
-            index:org.opencontainers.image.version=${{ steps.release.outputs.version }}
-            index:org.opencontainers.image.revision=${{ steps.commit.outputs.full_sha }}
-          cache-from: type=gha,scope=ocg-manager-linux-amd64
-          cache-to: type=gha,mode=max,scope=ocg-manager-linux-amd64
+            index:org.opencontainers.image.version=${{ needs.resolve.outputs.version }}
+            index:org.opencontainers.image.revision=${{ needs.resolve.outputs.full_sha }}
+          cache-from: type=gha,scope=ocg-manager-linux-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=ocg-manager-linux-${{ matrix.arch }}
           provenance: mode=max
           sbom: true
 
@@ -375,20 +402,38 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.browser
-          platforms: linux/amd64
-          outputs: type=image,name=${{ steps.release.outputs.browser_image }},push=true,push-by-digest=true,name-canonical=true
+          platforms: linux/${{ matrix.arch }}
+          outputs: type=image,name=${{ needs.resolve.outputs.browser_image }},push=true,push-by-digest=true,name-canonical=true,oci-mediatypes=true
           labels: ${{ steps.meta_browser.outputs.labels }}
           annotations: |
-            index:org.opencontainers.image.version=${{ steps.release.outputs.version }}
-            index:org.opencontainers.image.revision=${{ steps.commit.outputs.full_sha }}
-          cache-from: type=gha,scope=ocg-browser-linux-amd64
-          cache-to: type=gha,mode=max,scope=ocg-browser-linux-amd64
+            index:org.opencontainers.image.version=${{ needs.resolve.outputs.version }}
+            index:org.opencontainers.image.revision=${{ needs.resolve.outputs.full_sha }}
+          cache-from: type=gha,scope=ocg-browser-linux-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=ocg-browser-linux-${{ matrix.arch }}
           provenance: mode=max
           sbom: true
 
+      - name: Record amd64 digests
+        id: record_amd64
+        if: matrix.arch == 'amd64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "digest=${{ steps.push.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          echo "browser_digest=${{ steps.push_browser.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+      - name: Record arm64 digests
+        id: record_arm64
+        if: matrix.arch == 'arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "digest=${{ steps.push.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          echo "browser_digest=${{ steps.push_browser.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
   publish:
     name: Publish immutable and moving GHCR tags
-    needs: build
+    needs: [resolve, build]
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     concurrency:
@@ -417,19 +462,32 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish tags without moving immutable references or rolling channels back
+        id: publish_tags
         shell: bash
         env:
-          BROWSER_DIGEST: ${{ needs.build.outputs.browser_digest }}
-          BROWSER_IMAGE: ${{ needs.build.outputs.browser_image }}
-          CANDIDATE_VERSION: ${{ needs.build.outputs.version }}
-          MAIN_DIGEST: ${{ needs.build.outputs.digest }}
-          MAIN_IMAGE: ${{ needs.build.outputs.image }}
-          MINOR_CHANNEL: ${{ needs.build.outputs.minor }}
-          PUBLISH_LATEST: ${{ needs.build.outputs.publish_latest }}
-          SHORT_SHA: ${{ needs.build.outputs.short_sha }}
-          STABLE: ${{ needs.build.outputs.stable }}
+          BROWSER_DIGEST_AMD64: ${{ needs.build.outputs.browser_digest_amd64 }}
+          BROWSER_DIGEST_ARM64: ${{ needs.build.outputs.browser_digest_arm64 }}
+          BROWSER_IMAGE: ${{ needs.resolve.outputs.browser_image }}
+          CANDIDATE_VERSION: ${{ needs.resolve.outputs.version }}
+          FULL_SHA: ${{ needs.resolve.outputs.full_sha }}
+          MAIN_DIGEST_AMD64: ${{ needs.build.outputs.digest_amd64 }}
+          MAIN_DIGEST_ARM64: ${{ needs.build.outputs.digest_arm64 }}
+          MAIN_IMAGE: ${{ needs.resolve.outputs.image }}
+          MINOR_CHANNEL: ${{ needs.resolve.outputs.minor }}
+          PUBLISH_LATEST: ${{ needs.resolve.outputs.publish_latest }}
+          SHORT_SHA: ${{ needs.resolve.outputs.short_sha }}
+          STABLE: ${{ needs.resolve.outputs.stable }}
         run: |
           set -euo pipefail
+
+          for arch_digest_var in \
+            MAIN_DIGEST_AMD64 MAIN_DIGEST_ARM64 BROWSER_DIGEST_AMD64 BROWSER_DIGEST_ARM64; do
+            if [[ -z "${!arch_digest_var}" ]]; then
+              echo "Missing $arch_digest_var; both architecture legs must publish their digests." >&2
+              exit 1
+            fi
+          done
+
           inspect_digest() {
             local ref=$1
             local error_file="$RUNNER_TEMP/imagetools-inspect-error"
@@ -466,6 +524,11 @@ jobs:
             child_digest=$(jq -r '
               [.manifests[]? | select(.platform.os == "linux" and .platform.architecture == "amd64")][0].digest // empty
             ' <<<"$manifest")
+            if [[ -z "$child_digest" ]]; then
+              child_digest=$(jq -r '
+                [.manifests[]? | select(.platform.os == "linux" and .platform.architecture == "arm64")][0].digest // empty
+              ' <<<"$manifest")
+            fi
             if [[ -n "$child_digest" ]]; then
               image_ref="${ref%:*}@$child_digest"
             fi
@@ -487,13 +550,74 @@ jobs:
             fi
           }
 
+          arch_digests_for() {
+            local image=$1
+            if [[ "$image" == "$BROWSER_IMAGE" ]]; then
+              printf '%s %s' "$BROWSER_DIGEST_AMD64" "$BROWSER_DIGEST_ARM64"
+            else
+              printf '%s %s' "$MAIN_DIGEST_AMD64" "$MAIN_DIGEST_ARM64"
+            fi
+          }
+
+          merge_sources() {
+            local image=$1
+            local ref=$2
+            local amd64_digest
+            local arm64_digest
+            read -r amd64_digest arm64_digest <<<"$(arch_digests_for "$image")"
+            docker buildx imagetools create \
+              --tag "$ref" \
+              --annotation "index:org.opencontainers.image.version=$CANDIDATE_VERSION" \
+              --annotation "index:org.opencontainers.image.revision=$FULL_SHA" \
+              "$image@$amd64_digest" "$image@$arm64_digest"
+          }
+
+          verify_merged_index() {
+            local image=$1
+            local ref=$2
+            local amd64_digest
+            local arm64_digest
+            local annotation
+            local arch_manifests
+            local expected_manifests
+            local media_type
+            local raw
+            read -r amd64_digest arm64_digest <<<"$(arch_digests_for "$image")"
+            if ! raw=$(docker buildx imagetools inspect "$ref" --raw 2>"$RUNNER_TEMP/imagetools-index-error"); then
+              cat "$RUNNER_TEMP/imagetools-index-error" >&2
+              return 1
+            fi
+            arch_manifests=$(jq -r '[.manifests[]? | select(.platform.os == "linux") | .digest] | sort | join(",")' <<<"$raw")
+            expected_manifests=$(printf '%s\n%s\n' "$amd64_digest" "$arm64_digest" | LC_ALL=C sort | paste -sd, -)
+            if [[ "$arch_manifests" != "$expected_manifests" ]]; then
+              echo "Published index $ref does not merge exactly the candidate architecture manifests: $arch_manifests. An existing tag is immutable and cannot be replaced." >&2
+              return 1
+            fi
+            media_type=$(jq -r '.mediaType // empty' <<<"$raw")
+            if [[ "$media_type" != "application/vnd.oci.image.index.v1+json" ]]; then
+              echo "Published index $ref has media type '$media_type'; index annotations require an OCI image index. Rebuild with OCI media types before publishing." >&2
+              return 1
+            fi
+            annotation=$(jq -r '.annotations."org.opencontainers.image.version" // empty' <<<"$raw")
+            if [[ "$annotation" != "$CANDIDATE_VERSION" ]]; then
+              echo "Published index $ref carries version annotation '$annotation' instead of '$CANDIDATE_VERSION'." >&2
+              return 1
+            fi
+            local revision
+            revision=$(jq -r '.annotations."org.opencontainers.image.revision" // empty' <<<"$raw")
+            if [[ "$revision" != "$FULL_SHA" ]]; then
+              echo "Published index $ref carries revision annotation '$revision' instead of '$FULL_SHA'." >&2
+              return 1
+            fi
+          }
+
           check_immutable() {
             local image=$1
             local tag=$2
             local candidate_digest=$3
             local ref="$image:$tag"
             local existing
-            existing=$(inspect_digest "$ref")
+            existing=$(inspect_digest "$ref") || return 1
             node scripts/release-policy.mjs immutable-tag \
               --tag "$tag" \
               --candidate-digest "$candidate_digest" \
@@ -503,6 +627,7 @@ jobs:
           declare -A IMMUTABLE_DECISIONS
           declare -A MOVING_DECISIONS
           declare -A MOVING_CURRENT_VERSIONS
+          declare -A MOVING_EXISTING_DIGESTS
           declare -A EXPECTED_DIGESTS
           declare -A MOVING_EXPECTED_VERSIONS
 
@@ -555,9 +680,39 @@ jobs:
             MOVING_DECISIONS["$browser_ref"]=$browser_advance
             MOVING_CURRENT_VERSIONS["$main_ref"]=$main_current
             MOVING_CURRENT_VERSIONS["$browser_ref"]=$browser_current
-            EXPECTED_DIGESTS["$main_ref"]=$([[ "$main_advance" == true ]] && printf '%s' "$MAIN_DIGEST" || printf '%s' "$main_existing")
-            EXPECTED_DIGESTS["$browser_ref"]=$([[ "$browser_advance" == true ]] && printf '%s' "$BROWSER_DIGEST" || printf '%s' "$browser_existing")
+            MOVING_EXISTING_DIGESTS["$main_ref"]=$main_existing
+            MOVING_EXISTING_DIGESTS["$browser_ref"]=$browser_existing
             MOVING_EXPECTED_VERSIONS["$tag"]=$version
+          }
+
+          resolve_moving_expected_digests() {
+            local tag=$1
+            local main_ref="$MAIN_IMAGE:$tag"
+            local browser_ref="$BROWSER_IMAGE:$tag"
+            EXPECTED_DIGESTS["$main_ref"]=$([[ "${MOVING_DECISIONS["$main_ref"]}" == true ]] && printf '%s' "$MAIN_DIGEST" || printf '%s' "${MOVING_EXISTING_DIGESTS["$main_ref"]}")
+            EXPECTED_DIGESTS["$browser_ref"]=$([[ "${MOVING_DECISIONS["$browser_ref"]}" == true ]] && printf '%s' "$BROWSER_DIGEST" || printf '%s' "${MOVING_EXISTING_DIGESTS["$browser_ref"]}")
+          }
+
+          derive_candidate_index() {
+            local image=$1
+            local ref="$image:$CANDIDATE_VERSION"
+            local existing
+            existing=$(inspect_digest "$ref") || return 1
+            if [[ -z "$existing" ]]; then
+              merge_sources "$image" "$ref"
+              existing=$(inspect_digest "$ref")
+              if [[ -z "$existing" ]]; then
+                echo "Created $ref but could not read back its index digest." >&2
+                return 1
+              fi
+            fi
+            # buildx index assembly is deterministic (no timestamps or nonces), so an
+            # existing tag merging exactly these architecture manifests is the same
+            # digest a fresh create would produce; anything else must not be replaced.
+            # The explicit guard is required because errexit does not propagate into
+            # command substitutions and would silently continue with the old digest.
+            verify_merged_index "$image" "$ref" || return 1
+            printf '%s' "$existing"
           }
 
           publish_immutable() {
@@ -565,10 +720,10 @@ jobs:
             local tag=$2
             local candidate_digest=$3
             local decision=${IMMUTABLE_DECISIONS["$image:$tag"]}
-            local source_ref="$image@$candidate_digest"
             local ref="$image:$tag"
             if [[ "$decision" == create ]]; then
-              docker buildx imagetools create --tag "$ref" "$source_ref"
+              merge_sources "$image" "$ref"
+              verify_merged_index "$image" "$ref"
             else
               echo "Immutable tag $ref already resolves to the candidate digest; leaving it unchanged."
             fi
@@ -580,12 +735,12 @@ jobs:
             local tag=$2
             local candidate_digest=$3
             local key="$image:$tag"
-            local source_ref="$image@$candidate_digest"
             local ref="$key"
             local advance=${MOVING_DECISIONS["$key"]}
             local current_version=${MOVING_CURRENT_VERSIONS["$key"]}
             if [[ "$advance" == true ]]; then
-              docker buildx imagetools create --tag "$ref" "$source_ref"
+              merge_sources "$image" "$ref"
+              verify_merged_index "$image" "$ref"
               verify_published_digest "$ref" "$candidate_digest"
               echo "Advanced $ref from ${current_version:-none} to $CANDIDATE_VERSION."
             else
@@ -628,13 +783,28 @@ jobs:
             verify_paired_moving_tag "$tag"
           }
 
-          # Resolve both images completely before the first registry mutation.
-          preflight_immutable_image_tags "$MAIN_IMAGE" "$MAIN_DIGEST"
-          preflight_immutable_image_tags "$BROWSER_IMAGE" "$BROWSER_DIGEST"
+          # Decide every paired moving channel before the first registry mutation;
+          # these decisions compare remote channel versions and need no candidate
+          # digest.
           if [[ "$STABLE" == true ]]; then
             preflight_moving_pair "$MINOR_CHANNEL"
             if [[ "$PUBLISH_LATEST" == true ]]; then
               preflight_moving_pair latest
+            fi
+          fi
+
+          # Derive the merged multi-architecture index digests from the version tags
+          # (sidecar first) — the first registry writes — then finish the
+          # digest-dependent decisions before any further mutation.
+          BROWSER_DIGEST=$(derive_candidate_index "$BROWSER_IMAGE")
+          MAIN_DIGEST=$(derive_candidate_index "$MAIN_IMAGE")
+
+          preflight_immutable_image_tags "$MAIN_IMAGE" "$MAIN_DIGEST"
+          preflight_immutable_image_tags "$BROWSER_IMAGE" "$BROWSER_DIGEST"
+          if [[ "$STABLE" == true ]]; then
+            resolve_moving_expected_digests "$MINOR_CHANNEL"
+            if [[ "$PUBLISH_LATEST" == true ]]; then
+              resolve_moving_expected_digests latest
             fi
           fi
 
@@ -651,12 +821,15 @@ jobs:
             fi
           fi
 
+          echo "main_digest=$MAIN_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "browser_digest=$BROWSER_DIGEST" >> "$GITHUB_OUTPUT"
+
       - name: Verify public anonymous GHCR pulls
         shell: bash
         env:
-          BROWSER_IMAGE: ${{ needs.build.outputs.browser_image }}
-          CANDIDATE_VERSION: ${{ needs.build.outputs.version }}
-          MAIN_IMAGE: ${{ needs.build.outputs.image }}
+          BROWSER_IMAGE: ${{ needs.resolve.outputs.browser_image }}
+          CANDIDATE_VERSION: ${{ needs.resolve.outputs.version }}
+          MAIN_IMAGE: ${{ needs.resolve.outputs.image }}
         run: |
           set -euo pipefail
           anonymous_docker_config=$(mktemp -d)
@@ -665,16 +838,31 @@ jobs:
           docker pull --quiet "$MAIN_IMAGE:$CANDIDATE_VERSION"
           docker pull --quiet "$BROWSER_IMAGE:$CANDIDATE_VERSION"
 
+          verify_public_index() {
+            local ref=$1
+            local arches
+            arches=$(docker buildx imagetools inspect --raw "$ref" \
+              | jq -r '[.manifests[]? | select(.platform.os == "linux") | .platform.architecture] | sort | unique | join(",")')
+            if [[ "$arches" != "amd64,arm64" ]]; then
+              echo "Public manifest $ref does not expose both linux/amd64 and linux/arm64: $arches" >&2
+              exit 1
+            fi
+          }
+          verify_public_index "$MAIN_IMAGE:$CANDIDATE_VERSION"
+          verify_public_index "$BROWSER_IMAGE:$CANDIDATE_VERSION"
+          test "$(docker image inspect --format '{{.Architecture}}' "$MAIN_IMAGE:$CANDIDATE_VERSION")" = amd64
+          test "$(docker image inspect --format '{{.Architecture}}' "$BROWSER_IMAGE:$CANDIDATE_VERSION")" = amd64
+
       - name: Generate signed GitHub provenance
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
-          subject-name: ${{ needs.build.outputs.image }}
-          subject-digest: ${{ needs.build.outputs.digest }}
+          subject-name: ${{ needs.resolve.outputs.image }}
+          subject-digest: ${{ steps.publish_tags.outputs.main_digest }}
           push-to-registry: true
 
       - name: Generate signed GitHub provenance for browser image
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
-          subject-name: ${{ needs.build.outputs.browser_image }}
-          subject-digest: ${{ needs.build.outputs.browser_digest }}
+          subject-name: ${{ needs.resolve.outputs.browser_image }}
+          subject-digest: ${{ steps.publish_tags.outputs.browser_digest }}
           push-to-registry: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 - 非回环监听使用单管理员登录。Docker 可通过 `OCG_ADMIN_USERNAME` 和 `OCG_ADMIN_PASSWORD` 首次初始化（两个必须同时设置，只设一个会启动报错）；未提供时由首个注册者创建管理员。
 - 设置页通过受保护的 `/dashboard/api/settings/check-update` 手动检查 GitHub 最新 Release。内置升级公钥的已安装桌面版可继续下载、校验签名并原位安装；开发构建、CLI、Docker 与尚未进入升级通道的旧版保留发布页/手动覆盖路径。
 - 价格表通过受保护的 `GET /dashboard/api/pricing`、`PUT /dashboard/api/pricing/multipliers`、`POST /dashboard/api/pricing/refresh` 管理；只在用户点击刷新时访问 `https://opencode.ai/docs/go/`，不得自动轮询。
-- 公开 GitHub Release 发布后，`.github/workflows/container.yml` 构建并冒烟验证 `linux/amd64` 镜像，发布到 `ghcr.io/klarkxy/opencode-go-mgr`。Compose 默认使用该镜像；本地源码构建需设置 `OCG_IMAGE=ocg-manager:local` 后执行 `docker compose up -d --build`。
+- 公开 GitHub Release 发布后，`.github/workflows/container.yml` 在 amd64（`ubuntu-24.04`）与 arm64（`ubuntu-24.04-arm`）原生 runner 上构建并冒烟验证 `linux/amd64` 与 `linux/arm64` 镜像，各架构按 digest 推送后合并为同一 tag 的多架构 OCI index，发布到 `ghcr.io/klarkxy/opencode-go-mgr`。Compose 默认使用该镜像；本地源码构建需设置 `OCG_IMAGE=ocg-manager:local` 后执行 `docker compose up -d --build`。
 - `.github/workflows/quality.yml` 在 PR / `main` 上拆成三个并行 job：Web 测试/类型/lint、Linux workspace Rust 测试/Clippy（占位 `dist/`，编译含 Tauri crate）、Windows Tauri 定向测试（占位 `dist/`，不跑 Vite）。`release.yml` 的手动候选（即使选择 tag ref）始终无签名且可只构建指定平台；只有 `v*` tag 的 push 事件才构建三平台并读取 repository signing secrets。tag push 视为单维护者的明确发布授权：工作流在校验附件集合与组装产物逐名一致（数量由产物推导，不硬编码）、升级签名、公钥连续性与 GitHub 服务端 digest 后自动公开同一个未变更 draft。
 - 容器固定以 UID/GID `10001` 运行并内置 `LICENSE`；Compose 透传可选的 `OCG_MANAGER_ENCRYPTION_KEY` 以支持显式密钥恢复，正常部署仍优先保留卷内 `.encryption-key`。
 - 下游访问根地址优先级：非空 `OCG_CLIENT_ROOT_URL` > SQLite 手工值 > 前端按生产 origin / 开发 Gateway 端口自动推导。环境变量覆盖只读且不得写回 SQLite。

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ Install, first-client checks for all five protocols, backup, and upgrades:
 
 ## Docker
 
-Public image: `ghcr.io/klarkxy/opencode-go-mgr` (`linux/amd64`, anonymous
-pull). Save [`compose.example.yaml`](compose.example.yaml) (also attached to
-each Release) as `compose.yaml` and run:
+Public image: `ghcr.io/klarkxy/opencode-go-mgr` (`linux/amd64, linux/arm64`,
+anonymous pull). Save [`compose.example.yaml`](compose.example.yaml) (also
+attached to each Release) as `compose.yaml` and run:
 
 ```bash
 docker compose pull

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -1,10 +1,12 @@
 # Pull-only Docker Compose example for OCG Manager v1.8.0.
 # Save this file as compose.yaml. Optionally create a neighboring .env file
 # with OCG_PORT, OCG_IMAGE, OCG_BROWSER_IMAGE, or the runtime variables below.
+# The images are multi-architecture (linux/amd64 and linux/arm64); Compose
+# picks the host's native variant. On legacy Compose v1 or Podman-compose
+# without manifest-list support, re-add "platform: linux/amd64" to pin amd64.
 services:
   ocg-manager:
     image: ${OCG_IMAGE:-ghcr.io/klarkxy/opencode-go-mgr:1.8.0}
-    platform: linux/amd64
     restart: unless-stopped
     environment:
       - OCG_ADMIN_USERNAME
@@ -41,7 +43,6 @@ services:
   browser:
     profiles: ["browser"]
     image: ${OCG_BROWSER_IMAGE:-ghcr.io/klarkxy/opencode-go-mgr-browser:1.8.0}
-    platform: linux/amd64
     restart: unless-stopped
     environment:
       - OCG_BROWSER_CONTROL_ADDR=0.0.0.0:9080

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,22 +6,30 @@ variable "SMOKE_BROWSER_IMAGE" {
   default = "ocg-browser:smoke"
 }
 
+variable "CACHE_SCOPE" {
+  default = "ocg-manager-linux-amd64"
+}
+
+variable "CACHE_BROWSER_SCOPE" {
+  default = "ocg-browser-linux-amd64"
+}
+
 group "smoke" {
   targets = ["manager-smoke", "browser-smoke"]
 }
 
+# No explicit platforms: each native CI runner builds and loads its own
+# architecture, which is what the per-architecture smoke suite expects.
 target "manager-smoke" {
   context = "."
   dockerfile = "Dockerfile"
-  platforms = ["linux/amd64"]
   tags = ["${SMOKE_IMAGE}"]
-  cache-from = ["type=gha,scope=ocg-manager-linux-amd64"]
+  cache-from = ["type=gha,scope=${CACHE_SCOPE}"]
 }
 
 target "browser-smoke" {
   context = "."
   dockerfile = "Dockerfile.browser"
-  platforms = ["linux/amd64"]
   tags = ["${SMOKE_BROWSER_IMAGE}"]
-  cache-from = ["type=gha,scope=ocg-browser-linux-amd64"]
+  cache-from = ["type=gha,scope=${CACHE_BROWSER_SCOPE}"]
 }

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -420,7 +420,7 @@ Each CLI archive contains its executable, `dist/`, and `LICENSE`. Do not ship
 the CLI executable alone: `serve` needs the sibling dashboard assets. Windows
 has no portable GUI artifact.
 
-The `linux/amd64` container is published separately as
+The `linux/amd64` and `linux/arm64` containers are published separately as
 `ghcr.io/klarkxy/opencode-go-mgr`; the GitHub Release contains the seven
 ordinary platform payloads, the extra macOS updater archive, four updater
 signatures, the pull-only Compose example, `latest.json`, and `SHA256SUMS`
@@ -650,8 +650,10 @@ clients cannot trust a release signed only by the replacement key.
 Release published by `release.yml` with `github.token` does not recursively
 start another workflow. After the signed tag pipeline publishes the Release,
 dispatch `container.yml` explicitly for that tag with `publish_latest=true`
-for a stable release. It checks out the release tag and, via `docker-bake.hcl`, builds both
-`linux/amd64` smoke images in parallel: the main
+for a stable release. It checks out the release tag and builds each
+architecture natively (amd64 on `ubuntu-24.04`, arm64 on `ubuntu-24.04-arm` —
+no QEMU emulation for release artifacts). Via `docker-bake.hcl`, each leg
+builds its own `linux/<arch>` smoke images in parallel: the main
 `ghcr.io/klarkxy/opencode-go-mgr` service and the
 `ghcr.io/klarkxy/opencode-go-mgr-browser` sidecar. The main smoke covers the
 dashboard, authentication, and license. The browser smoke starts Xvfb/noVNC
@@ -660,9 +662,12 @@ configuration, and no host-published port, then uses the token-protected
 control API to launch a real ordinary Chromium process with a persistent
 profile.
 
-Both verified results are pushed by digest without assigning a mutable name,
-then enter the repository-wide serialized tag queue. `X.Y.Z` and
-`sha-<12-character-commit>` are created only when absent; an existing tag is
+All verified results — two images per architecture — are pushed by digest
+without assigning a mutable name, then enter the repository-wide serialized
+tag queue. `X.Y.Z` and `sha-<12-character-commit>` are assembled by merging
+the two architecture digests into one multi-architecture OCI index (with
+explicit index version/revision annotations, since multi-source assembly
+does not inherit them) and are created only when absent; an existing tag is
 accepted only when its image's exact candidate digest already matches.
 Stable `X.Y` and opted-in `latest` are decided as a pair: the workflow either
 converges both image channels at the candidate or retains an already aligned
@@ -739,11 +744,12 @@ Pull requests automatically receive the three-job quality gate: frontend
 checks, Linux workspace Rust tests/Clippy (including the Tauri crate), and
 the Windows job that covers compilation and unit tests for Windows-only
 Tauri behavior. Native installer/package smokes remain manual release
-candidates or tag runs. The container workflow covers `linux/amd64` only
-and runs after a release is published or manually dispatched.
+candidates or tag runs. The container workflow covers `linux/amd64` and
+`linux/arm64` (each built and smoke-tested on its native runner) and runs
+after a release is published or manually dispatched.
 
 CI does not drive real desktop UI interactions or launch real Claude Desktop
-or Gemini CLI clients, and it does not test container ARM64, backup/restore,
+or Gemini CLI clients, and it does not test backup/restore,
 database downgrade, migration rollback, an upstream account, or a real
 gateway request. Rust tests cover Gemini/Claude Desktop routing,
 authentication, alias rewriting, non-stream conversion, and SSE event shapes,

--- a/docs/MAINTAINER.zh-CN.md
+++ b/docs/MAINTAINER.zh-CN.md
@@ -356,7 +356,7 @@ SHA256SUMS
 每个 CLI 压缩包都包含可执行文件、`dist/`、`LICENSE`。**不要** 只发 CLI 可执
 行文件：`serve` 需要同级的 `dist/`。Windows 没有 portable GUI 安装包。
 
-`linux/amd64` 容器单独发布为 `ghcr.io/klarkxy/opencode-go-mgr`。GitHub Release
+`linux/amd64` 与 `linux/arm64` 容器单独发布为 `ghcr.io/klarkxy/opencode-go-mgr`。GitHub Release
 包含七份常规平台 payload、额外的 macOS 升级压缩包、四份升级签名、只拉取镜像
 的 Compose 示例、`latest.json` 与 `SHA256SUMS`（当前共 15 个附件）。本地验证器
 固定校验当前这 15 个文件，工作流同时要求 GitHub 附件的名称与数量和组装后的
@@ -532,16 +532,19 @@ closed。密钥轮换属于 break-glass 恢复，不是普通 secret 更新。�
 `.github/workflows/container.yml` 接受 Release 发布事件，但由 `release.yml` 使用
 `github.token` 公开的 Release 不会递归启动另一个工作流。签名 tag 流水线公开
 Release 后，稳定版必须对该 tag 显式触发 `container.yml`，并设置
-`publish_latest=true`。该工作流检出 Release tag，通过 `docker-bake.hcl` 并行构建
-两个 `linux/amd64` 冒烟镜像：主服务
+`publish_latest=true`。该工作流检出 Release tag，在各架构原生 runner 上构建
+（amd64 用 `ubuntu-24.04`、arm64 用 `ubuntu-24.04-arm`，发布产物不经 QEMU 模
+拟），并通过 `docker-bake.hcl` 并行构建本架构的冒烟镜像：主服务
 `ghcr.io/klarkxy/opencode-go-mgr` 与 Sidecar
 `ghcr.io/klarkxy/opencode-go-mgr-browser`。主镜像冒烟检查 Dashboard、鉴权和许可
 证；浏览器镜像在只读根文件系统、零 capability、Chromium 可用的 seccomp
 配置、无宿主机端口下启动 Xvfb/noVNC，并通过受 token 保护的控制 API 真正拉起
 普通 Chromium 与持久 Profile。
 
-两个镜像都先按 digest 推送而不分配可变名称，再进入仓库级串行标签队列。
-`X.Y.Z` 与 `sha-<12 位 commit>` 仅在不存在时创建；已存在时只有各自 digest 与
+全部验证通过的产物——每架构两个镜像——先按 digest 推送而不分配可变名称，再进入
+仓库级串行标签队列。`X.Y.Z` 与 `sha-<12 位 commit>` 由两个架构的 digest 合并为
+单一多架构 OCI index（显式携带 index 版本/revision 注解，多源组装不继承源注解），
+仅在不存在时创建；已存在时只有各自 digest 与
 候选完全相同才接受，否则失败。稳定版 `X.Y` 和选择更新的 `latest` 按镜像对整体
 决策：要么都收敛到候选版本，要么保留已经对齐的较新版本对；若通道仍会分裂，工作
 流会失败而不是静默保留。两个镜像各自记录 SPDX SBOM、BuildKit SLSA provenance
@@ -603,11 +606,12 @@ Docker 仍走直接/手动路径。
 
 PR 会自动运行三路并行质量门：前端检查、Linux workspace Rust 测试/Clippy（含
 Tauri crate），以及覆盖 Windows 专属 Tauri 行为编译和单测的 Windows job；原生
-安装包/打包冒烟仍只在手动候选或 tag 流程运行。容器工作流只覆盖 `linux/amd64`，
-并且只在 Release 发布后或手动触发时运行。
+安装包/打包冒烟仍只在手动候选或 tag 流程运行。容器工作流覆盖 `linux/amd64` 与
+`linux/arm64`（各自在原生 runner 上构建并冒烟），并且只在 Release 发布后或手动
+触发时运行。
 
-CI 不会操作真实桌面 UI，也不启动真实 Claude Desktop 或 Gemini CLI，不测试容
-器 ARM64、备份恢复、数据库降级、迁移回滚、真实上游账号或真实 Gateway 请求。
+CI 不会操作真实桌面 UI，也不启动真实 Claude Desktop 或 Gemini CLI，不测试备份
+恢复、数据库降级、迁移回滚、真实上游账号或真实 Gateway 请求。
 Rust 测试覆盖 Gemini/Claude Desktop 路由、鉴权、别名改写、非流式转换和 SSE 事
 件形状，但不能证明第三方客户端的新版本仍接受生成的配置。容器冒烟只检查 TCP
 健康、Dashboard HTML、auth status、镜像内许可证，以及未登录 settings 返回

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -991,8 +991,9 @@ dashboard.
 ## Docker
 
 The public headless image can be pulled from GHCR without signing in. It is a
-Linux container and currently publishes `linux/amd64` only; there is no
-native ARM64 image. Each release also includes a pull-only
+Linux container publishing `linux/amd64` and `linux/arm64`; a plain
+`docker pull` selects the matching native variant on either architecture. Each
+release also includes a pull-only
 `compose.example.yaml`; save it as `compose.yaml` and optionally create a
 neighboring `.env`. The example pins its matching release by default, while
 `OCG_IMAGE` can override it. Alternatively, run the Compose commands from a
@@ -1271,9 +1272,11 @@ and browser profiles.
   `show_dock_icon` switch.
 - Windows / Linux ARM64 and 32-bit x86 builds are not published. RPM, Snap,
   app-store packages, Windows Authenticode signing, and Apple notarization
-  are not implemented. Updater-enabled installed desktop builds can install
-  signed releases from Settings; 1.4.1, development builds, the CLI, and
-  Docker use the direct/manual upgrade path.
+  are not implemented. That covers desktop installers only; the container
+  images (`ghcr.io/klarkxy/opencode-go-mgr` and its `-browser` sidecar)
+  publish `linux/amd64` and `linux/arm64`. Updater-enabled installed desktop
+  builds can install signed releases from Settings; 1.4.1, development
+  builds, the CLI, and Docker use the direct/manual upgrade path.
 
 ## Troubleshooting
 

--- a/docs/USER.zh-CN.md
+++ b/docs/USER.zh-CN.md
@@ -813,8 +813,9 @@ ocg-manager-cli
 
 ## Docker
 
-GHCR 上的公开无头镜像无需登录即可拉取。它是 Linux 容器，目前只发布
-`linux/amd64`，没有原生 ARM64 镜像。每个 Release 也会附带只拉取镜像的
+GHCR 上的公开无头镜像无需登录即可拉取。它是 Linux 容器，发布 `linux/amd64`
+与 `linux/arm64`；直接 `docker pull` 会在对应架构上自动选择原生变体。每个
+Release 也会附带只拉取镜像的
 `compose.example.yaml`；把它保存为 `compose.yaml`，并按需在同目录创建 `.env`。
 示例默认固定对应的发布版本，也可用 `OCG_IMAGE` 覆盖。或者在包含 `compose.yaml`
 与 `.env.example` 的仓库目录中运行（建议检出对应 Release tag）：
@@ -1044,7 +1045,9 @@ ocg.example.com {
 - macOS 桌面版可以在设置中隐藏 Dock 图标而只保留菜单栏图标；Windows、Linux、
   CLI 与 Docker 不暴露 `show_dock_icon` 开关。
 - 不发布 Windows / Linux ARM64、32 位 x86 构建；不支持 RPM、Snap、应用商店包、
-  Windows Authenticode 正式签名、Apple 公证。支持升级的已安装桌面版可在设置页
+  Windows Authenticode 正式签名、Apple 公证。该口径仅覆盖桌面安装包；容器镜像
+  （`ghcr.io/klarkxy/opencode-go-mgr` 及其 `-browser` 侧车）发布
+  `linux/amd64` 与 `linux/arm64`。支持升级的已安装桌面版可在设置页
   安装签名 Release；v1.4.1、开发构建、CLI、Docker 使用直接/手动升级路径。
 
 ## 常见问题

--- a/openspec/changes/docker-arm64-release/.openspec.yaml
+++ b/openspec/changes/docker-arm64-release/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/docker-arm64-release/design.md
+++ b/openspec/changes/docker-arm64-release/design.md
@@ -1,0 +1,72 @@
+## Context
+
+`container.yml` 的 build job 在单个 `ubuntu-24.04` 上构建两个镜像（`Dockerfile` 主镜像 + `Dockerfile.browser` 侧车），先以 bake 构建 smoke 镜像跑完整冒烟（主镜像健康检查/dashboard/401；侧车真实 Chromium 启动与加固断言），再以 `push-by-digest=true` 推送单平台镜像，最后 publish job 用 `docker buildx imagetools create` 组装 version/`sha-`/minor/latest 并做不可变校验、配对通道（paired-channel）推进、匿名拉取验证与签名 provenance。这个"digest 推送 + 远端组装"结构正是多架构清单的标准做法，改动集中在编排层。依赖已核实全绿：reqwest 系 rustls（纯 Rust、无 OpenSSL）、无 `cfg(target)` 原生分支、三个基础镜像官方多架构、Debian bookworm arm64 具备 chromium 与全部 X 组件。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 每架构原生构建 + 原生冒烟，发布产物不经 QEMU
+- 已有 tag 从单平台 manifest 变为双架构 OCI index，且旧 tag 不受影响
+- 配对通道、不可变策略、provenance、匿名拉取验证语义全部保留
+- 首次发布走 `workflow_dispatch` + 临时 tag 演练后才进正式渠道
+
+**Non-Goals:**
+
+- 桌面端（Tauri）ARM64/安装包、`quality.yml` 架构扩展、RPM/Snap（维持 USER 文档"桌面不发布 ARM64"口径，仅镜像声明变更）
+- `Dockerfile` / `Dockerfile.browser` 任何改动
+- `release-policy.mjs` 策略逻辑改动（digest 对比天然兼容 index）
+
+## Decisions
+
+### D1: 原生 runner matrix，不用 QEMU 交叉构建
+
+build job 加 `strategy.matrix.arch: [amd64, arm64]`，runner 映射 `amd64→ubuntu-24.04`、`arm64→ubuntu-24.04-arm`（公共仓库免费）。理由：QEMU 模拟下两个 cargo release 构建 + 真实 Chromium 冒烟既慢又不可靠（在 120 分钟 timeout 内完成模拟构建风险高、模拟 Chromium 假失败/假通过），原生构建时长与 amd64 相当且冒烟结果可信。代价：matrix 两腿并行使 job 数翻倍， arm64 runner 冷启动可能排队——用按架构区分的 GHA cache（scope 加 `-amd64`/`-arm64` 后缀）缓解增量构建时长。
+
+### D2: 平台参数化与每架构独立 smoke
+
+**前提修正**：当前 `docker-bake.hcl` 两个 smoke target 与 `container.yml` 两处 build-push 步骤**都硬编码了 `linux/amd64`**。matrix 化必须同步：build-push `platforms` 改为 `linux/${{ matrix.arch }}`；bake smoke target **删除**现有 `platforms` pin——删除后 bake 在各原生 runner 上默认产出本机架构镜像，arm64 腿才真正构建 arm64。若只加 matrix 不动 platforms，arm64 腿会把 amd64 镜像经 QEMU 烤出（慢且冒烟跑在模拟 Chromium 上），合并出双 amd64 index，与变更目标相反——这是本变更最易漏也最致命的一步，已列为 task 1.5 并由 task 3.3 的接线断言防回归。
+
+smoke 资源名追加 `-${{ matrix.arch }}` 后缀属防御性整洁（两腿在独立 runner VM 上本不冲突，后缀让日志与清理一目了然）。每腿跑完整现有冒烟——这正是 spec"每架构原生冒烟"要求，且失败即整腿失败、publish 依赖两腿全部成功，天然满足"arm64 失败阻塞双架构发布"。
+
+### D3: outputs 携带按架构 digest，publish 合并两源；digest 确定性澄清
+
+build job 的 outputs 从 `digest`/`browser_digest` 改为 `digest_amd64`/`digest_arm64`/`browser_digest_amd64`/`browser_digest_arm64`（matrix job 的 outputs 会被各腿覆盖，因此每腿只写自己架构的两个 output；tag/version 等元数据经独立 resolve job 统一产出，见 task 1.4）。publish job 的 `imagetools create --tag <ref> --annotation ... <image>@<digest_amd64> <image>@<digest_arm64>` 以两源合并出 index。
+
+**澄清**：buildx 的 `imagetools create` (`combine`) 只产出 OCI image-index，由 `mediaType` / `schemaVersion:2` / `manifests[]` 子清单描述符 / `annotations{}` 组成——**没有时间戳、随机 nonce 或 created annotation**，因此同样的子清单 digest 与 annotation 输入下两次 create 产出 byte-identical 的 index（同一 digest）。候选 index digest 的推导顺序定案为：先对 version tag 执行两源 create 并 `inspect_digest` 回读，该 digest 借确定性复用于 `sha-`/minor/latest 的全部预检——既给出可执行的推导机制，又保住"全部决策先于首次（移动通道）变更"的既有顺序约束；`check_immutable`/`paired-channel` 的 digest 比较路径语义不变，`release-policy.mjs` 不改。**实现细化**：paired-channel 决策只比较远端通道版本、不依赖候选 digest，实际接线中提升到 derive 之前执行（`EXPECTED_DIGESTS` 在 derive 后回填），使"决策先于首次写入"的窗口收窄到仅剩 `sha-` 预检——其候选 digest 必须由 create 推导，属固有代价。
+
+### D4: index 版本注解必须显式写入；OCI 媒体类型为前提
+
+两层事实决定实现方式：
+
+1. **多源 `imagetools create` 不继承 annotation**。现有单源 create 之所以 annotation 生效，是因为它实质把 build 阶段已带 `index:` 注解的单平台 index 直接重挂 tag；双源 create 构造全新 index，源 annotation 一概丢弃。因此两源 create **必须显式带** `--annotation index:org.opencontainers.image.version=$CANDIDATE_VERSION`（及 `index:org.opencontainers.image.revision`），否则 index 无版本注解、annotation-first 路径必然落空。
+2. **annotation 只落在 OCI index**。`imagetools create` 按子清单媒体类型决定 index media type：全 Docker schema 2 → Docker manifest list（annotation 整段丢弃）；含 OCI → OCI image index（annotation 生效）。现有 build-push 因 `provenance: mode=max` + `sbom: true`（attestation 要求 OCI 媒体类型）默认产出 OCI 子清单，但这是隐式依赖——本变更在 build-push `outputs:` 显式声明 `oci-mediatypes=true` 加以锁定，并在 publish 步骤对每个 index 用 `imagetools inspect` 校验 `mediaType` 为 `application/vnd.oci.image.index.v1+json`，不满足即 fail-fast。
+
+`inspect_version` 读取顺序：优先 index annotation `org.opencontainers.image.version`（由第 1 条显式写入保证）；缺失时按 `[amd64, arm64]` 顺序取首个子清单读 label（与既有 amd64 优先行为兼容，覆盖旧单平台 tag）。
+
+### D5: 演练通道先行
+
+新增/复用 `workflow_dispatch` 路径，用非 stable 的临时 tag（如 `v0.0.0-arm64-rehearsal-N`）在真实 GHCR 上全流程演练（两架构构建、合并、匿名拉取、provenance），验证 `docker pull` 于两架构各自解析正确后删除演练 tag，再执行一次正式 release。理由：多架构 index 组装与策略脚本回退路径只有真实远端才能验证；临时非 stable tag 不会触碰 minor/latest 移动通道。
+
+### D6: 文档口径一次改齐
+
+USER 双语两处"仅 amd64"、README 镜像平台行、`compose.example.yaml` 两处 `platform: linux/amd64`（删除，让 compose 自动选本机架构；保留注释说明如需强制锁定可自行加回）、AGENTS.md 项目事实。桌面"不发布 ARM64"表述保留但补"（容器镜像除外）"式限定，避免读者混淆。
+
+## Risks / Trade-offs
+
+- [arm64 免费_runner 排队/配额波动] → 构建无硬性时限压力（release 触发非紧急路径）；cache scope 按架构预热；若长期不可用可降级 QEMU 仅构建不冒烟（明确不走）或推迟本变更。
+- [matrix outputs 覆盖踩坑] → 每腿仅写本架构 output（`digest_${{ matrix.arch }}`）；在 publish job 前 `assert` 四个 digest 全非空，缺失即 fail-fast。
+- [index 媒体类型退化让 annotation 路径静默失效] → D4：build-push 显式声明 OCI；publish 后 `imagetools inspect` 校验 index `mediaType` 为 OCI image-index，失败即 fail-fast。
+- [演练 tag 长期滞留 GHCR] → 演练专属非 stable tag 一次性使用，发布成功后由维护者删除（见 task 5.4）。
+- [合并清单体积/拉取体验] → 双架构 index 对单架构宿主透明（registry 按需分发对应层）；镜像体积仅构建侧 ×2，用户侧不变。
+- [浏览器侧车 arm64 字体/编码差异导致冒烟不稳] → 冒烟断言全部来自既有 amd64 用例；arm64 首次演练若暴露字体渲染差异，仅影响冒烟脚本的容错调整，不影响镜像内容（Debian 同源包）。
+
+## Migration Plan
+
+1. 合并本变更后，先跑 `workflow_dispatch`（tag=演练 tag，`publish_latest=false`）走全流程；在 amd64 与 arm64 机各 `docker pull` 验证架构解析；删除演练 tag。
+2. 下一个正式 Release 照常触发，产出首个双架构正式 tag；旧 tag（单平台）不受影响。
+3. 回滚：`workflow_dispatch` 支持 `source_ref` 热修复；若需整体回退，revert 工作流改动即可——已发布的多架构 tag 保持不动（不可变策略禁止重写）。
+
+## Open Questions
+
+（无——runner 可用性风险已列为 trade-off 并给出降级判断；其余实现细节在 tasks 粒度内可定。）

--- a/openspec/changes/docker-arm64-release/proposal.md
+++ b/openspec/changes/docker-arm64-release/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+容器镜像目前只发布 `linux/amd64`（`container.yml` 硬编码单平台），ARM 服务器/NAS/树莓派等自托管用户只能依赖 QEMU 用户态模拟运行 amd64 镜像，性能差且 Chromium 侧车在模拟下基本不可用。GitHub 已为公共仓库提供免费的 `ubuntu-24.04-arm` 原生 runner，且现有发布流水线本就是"按 digest 推送 + imagetools 组装 tag"的多架构就绪形态——补齐 arm64 的成本集中在 CI 编排，不在代码。
+
+## What Changes
+
+- **build job 改架构 matrix**：`container.yml` 的 build job 从单 `ubuntu-24.04` 改为 matrix（`amd64` → `ubuntu-24.04`、`arm64` → `ubuntu-24.04-arm`）；两处 build-push 的 `platforms` 由硬编码 `linux/amd64` 参数化为 `linux/${{ matrix.arch }}`，`docker-bake.hcl` smoke 目标删除现有 `platforms` pin（否则 arm64 腿会烤出 amd64 镜像）；每个架构原生构建主镜像与 browser 侧车镜像、原生执行现有全部 smoke（含真实 Chromium 启动检查），各自以 `push-by-digest=true` 推送单平台镜像；release 元数据（tag/version/minor 等）由新增独立 resolve job 统一产出。
+- **publish job 合并多架构清单**：`docker buildx imagetools create` 从单一 digest 源改为合并两个架构 digest（显式带 `--annotation index:org.opencontainers.image.version/revision`——多源 create 不继承源注解），产出同一个 version / `sha-<short>` / minor / latest tag 的 OCI index；配对通道（main 与 browser 同步推进）语义不变。
+- **按架构修正细节**：`inspect_version` 优先读 index annotation、缺失时按 `[amd64, arm64]` 顺序取首个子清单；build-push 显式 `oci-mediatypes=true` 并在 publish 后校验 index mediaType 为 OCI（annotation 仅落于 OCI index）；GHA build cache scope 按架构区分（amd64 字符串不变、既有缓存继续命中）；smoke 资源命名按 run+arch 加后缀（并发组保持 tag 级不并入 arch）。
+- **文档与口径同步**：`docs/USER.md` / `USER.zh-CN.md`（"仅 amd64"两处）、`docs/MAINTAINER.md` / `MAINTAINER.zh-CN.md`（发布矩阵与平台覆盖表述）、`README.md`（镜像平台说明）、`compose.example.yaml`（`platform: linux/amd64` 锁定移除并加英文回锁注释）、`AGENTS.md` 项目事实；明确"桌面端仍不发布 ARM64 安装包，本变更仅覆盖容器镜像"。
+- **零代码改动**：`Dockerfile` / `Dockerfile.browser` 不改（依赖已验证：rustls 纯 Rust 无 OpenSSL，基础镜像官方多架构，Debian bookworm arm64 具备 chromium 及全套 X 组件）；`release-policy.mjs` 不可变 tag 逻辑基于 digest 对比，天然兼容多架构 index。
+
+## Capabilities
+
+### New Capabilities
+
+- `container-arm64-release`：容器发布渠道的多架构交付契约——两架构原生构建与 smoke、digest 级合并发布、配对通道不拆分、平台声明与文档口径。
+
+### Modified Capabilities
+
+（无——`openspec/specs/` 无主规格，本能力全新定义。）
+
+## Impact
+
+- **CI**：`.github/workflows/container.yml` 是唯一实质改动面（build job matrix 化、outputs 携带按架构 digest、publish job 合并源、inspect 回退、cache scope、smoke 资源命名）；`docker-bake.hcl` smoke 目标保持本机架构原生构建（不加 platforms 交叉）。
+- **发布产物**：`ghcr.io/klarkxy/opencode-go-mgr` 与 `ghcr.io/klarkxy/opencode-go-mgr-browser` 的既有 tag 从单平台 manifest 变为多架构 OCI index；旧 tag 不受影响（不可变策略只管新发布）。
+- **文档**：USER 双语、README、compose 示例、AGENTS.md。
+- **风险面**：arm64 原生构建时长与缓存冷启动；免费 arm64 runner 的配额与可用性；首次多架构发布必须先经 `workflow_dispatch` + 临时 tag 演练（发布到测试 tag，验证合并清单与匿名拉取后再进正式渠道）。
+- **不在范围**：桌面端（Tauri）ARM64 安装包、Windows/Linux ARM64 原生构建、RPM/Snap、`quality.yml` 的架构扩展。

--- a/openspec/changes/docker-arm64-release/specs/container-arm64-release/spec.md
+++ b/openspec/changes/docker-arm64-release/specs/container-arm64-release/spec.md
@@ -1,0 +1,65 @@
+## Purpose
+
+Defines the multi-architecture delivery contract for the published container images: both `linux/amd64` and `linux/arm64` variants of the manager and browser-sidecar images are built natively, smoke-tested on their own architecture, and published as one merged manifest per tag without splitting the paired release channels.
+
+## ADDED Requirements
+
+### Requirement: Published image tags resolve for both amd64 and arm64
+
+Every container tag published through the release channel (the immutable `version` and `sha-<short>` tags, and the moving `minor` / `latest` channels when they advance) SHALL be a single multi-architecture manifest index containing exactly the `linux/amd64` and `linux/arm64` variants. A plain `docker pull <tag>` on either architecture MUST select and run the matching variant without emulation.
+
+#### Scenario: Pull on an arm64 host selects the native variant
+
+- **WHEN** the version tag has been published and a host with `linux/arm64` architecture pulls the manager or browser image by tag
+- **THEN** the pulled image architecture reports `arm64` and the container starts without QEMU/binfmt emulation
+
+#### Scenario: Pull on an amd64 host is unchanged
+
+- **WHEN** an amd64 host pulls any published tag after this change
+- **THEN** it receives the `linux/amd64` variant of the same build, as before
+
+### Requirement: Each architecture is built and smoke-tested natively
+
+The release pipeline SHALL build every image variant on a runner matching its target architecture (no cross-compilation and no QEMU-emulated builds for release artifacts), and the existing smoke suite — manager health/dashboard/auth checks and the browser container's live Chromium verification — MUST pass on each architecture before its digest enters the published manifest.
+
+#### Scenario: An arm64 smoke failure blocks the release
+
+- **WHEN** the arm64 leg of the build matrix fails its smoke test (for example Chromium does not start)
+- **THEN** no tag for that release is published or advanced on either architecture
+
+#### Scenario: Browser smoke verifies real Chromium on arm64
+
+- **WHEN** the browser sidecar smoke runs on the arm64 build leg
+- **THEN** it launches the arm64 Chromium from the image and asserts the same hardening flags and profile isolation as the amd64 leg
+
+#### Scenario: Build legs run on architecture-matched runners
+
+- **WHEN** the build job's matrix dispatches its legs
+- **THEN** the amd64 leg's runner label resolves to `ubuntu-24.04` (not the arm variant) and the arm64 leg's runner label resolves to `ubuntu-24.04-arm` — pins native arm64 builds and rules out a silent QEMU-emulated release.
+
+### Requirement: Paired channels stay atomic across architectures and images
+
+The existing pairing guarantee — a moving tag on the manager image and on the browser sidecar image MUST resolve to the same release version, with the sidecar published first — SHALL be preserved for the merged multi-architecture manifests. A failed or partial publish MUST NOT leave one architecture or one image advanced without the other.
+
+#### Scenario: Moving channel advance is all-or-nothing
+
+- **WHEN** a stable release advances the minor or latest channel
+- **THEN** both images' channel tags point at multi-architecture indexes of the same version, and no intermediate state exposes one image or one architecture from a different version
+
+### Requirement: Immutable tag policy applies to the merged manifest digest
+
+The existing immutability and anti-rollback policy SHALL operate on the merged manifest index digest: an already-published version or `sha-` tag MUST NOT be recreated or overwritten, and a re-run for the same release MUST verify that the tag resolves to the same index digest.
+
+#### Scenario: Re-publishing the same version tag is a no-op
+
+- **WHEN** the workflow runs again for a version whose tags already exist
+- **THEN** the existing tags are left unchanged and the run verifies their digest matches the candidate index digest
+
+### Requirement: Published platform claims match reality
+
+User-facing documentation and shipping examples (user guide in both languages, README, compose example, maintainer notes) SHALL state that the container images provide `linux/amd64` and `linux/arm64`, and MUST NOT imply native ARM64 availability for the desktop installers, which remain out of scope.
+
+#### Scenario: Compose example no longer pins amd64
+
+- **WHEN** a user deploys the example compose file on an arm64 host
+- **THEN** no `platform:` pin forces amd64 emulation; the deployment uses the native arm64 variant

--- a/openspec/changes/docker-arm64-release/tasks.md
+++ b/openspec/changes/docker-arm64-release/tasks.md
@@ -1,0 +1,37 @@
+## 1. build job matrix 化
+
+- [x] 1.1 `container.yml` build job 加 `strategy.matrix.arch: [amd64, arm64]` 与 `include:` 段（`arch: amd64, runs-on: ubuntu-24.04`、`arch: arm64, runs-on: ubuntu-24.04-arm`），`timeout-minutes` 保持 120；`concurrency.group` 维持 `ghcr-<tag>` 不变——workflow 级并发组只作用于跨 run 的同 tag 串行（期望行为），matrix 两腿属同一 run 内的不同 job，本就不经该组交互，**不**并入 arch
+- [x] 1.2 smoke 资源环境变量（`SMOKE_IMAGE`/`SMOKE_BROWSER_IMAGE`/`SMOKE_CONTAINER`/`SMOKE_VOLUME` 等全部）追加 `-${{ matrix.arch }}` 后缀（防御性：两条腿理论上各在独立 runner VM，本地 Docker 资源本不冲突；后缀无成本且让日志/清理一目了然）
+- [x] 1.3 `docker-bake.hcl` 新增 `variable "CACHE_SCOPE" { default = "ocg-manager-linux-amd64" }` 与 `variable "CACHE_BROWSER_SCOPE" { default = "ocg-browser-linux-amd64" }`；两个 smoke target 的 `cache-from` 改为引用变量；`container.yml` 的 `vars:` 块追加 `CACHE_SCOPE=ocg-manager-linux-${{ matrix.arch }}`、`CACHE_BROWSER_SCOPE=ocg-browser-linux-${{ matrix.arch }}`；两处 build-push 步骤的 `cache-from`/`cache-to` scope 同步改为引用同名变量（scope 字符串 amd64 腿与既有完全一致、已存在缓存继续命中；arm64 腿为新命名空间）
+- [x] 1.4 build job `outputs` 重构：**采用 Option B 引入独立 resolve job**——把"解析 release tag/version/minor/stable/publish_latest"、"Check out release source + 校验版本一致"、"Resolve release commit"整体移至 resolve job（`permissions: contents: read`），产出 `tag`/`version`/`minor`/`stable`/`publish_latest`/`image`/`browser_image`/`full_sha`/`short_sha`；build job 改为 `needs: resolve`、各腿自行 checkout（ref 取 `needs.resolve.outputs.tag` 对应的 tag），outputs 仅 `digest_${{ matrix.arch }}` / `browser_digest_${{ matrix.arch }}` 两组（每腿只写本架构两个）；publish job 改 `needs: [resolve, build]` 并把原 `steps.release.outputs.*` 全部改指 `needs.resolve.outputs.*`
+- [x] 1.5 **平台参数化（关键）**：两处 build-push 步骤的 `platforms: linux/amd64` 改为 `platforms: linux/${{ matrix.arch }}`；`docker-bake.hcl` 两个 smoke target **删除**现有硬编码 `platforms = ["linux/amd64"]`（当前文件带 pin，不删则 arm64 腿会把 amd64 镜像经 QEMU 烤出来、合并出双 amd64 index——与变更目标相反）；删除后 bake 在各原生 runner 上默认产出本机架构镜像
+
+## 2. publish job 多架构合并
+
+- [x] 2.1 publish job 前置校验：四个架构 digest 全非空，缺失即 fail-fast；`verify_published_digest`/`inspect_digest` 沿用
+- [x] 2.2 不可变 tag（version/`sha-`）——**候选 digest 推导顺序定案**：先对 version tag 执行两源 create（附 2.2 的 annotation），`inspect_digest` 回读该 index digest 作为本次发布的候选 digest，再按 D3 确定性复用于 `sha-`/minor/latest 的全部预检（保持"全部决策先于首次变更"的既有顺序）；已存在 → 校验 digest 一致跳过，不存在 → create 后回读校验（buildx `combine` 无时间戳/nonce，同源重放同 digest；`release-policy.mjs` 不改）
+- [x] 2.3 每个两源 create 调用**必须带 `--annotation index:org.opencontainers.image.version=$CANDIDATE_VERSION` 与 `index:org.opencontainers.image.revision=$FULL_SHA`**——多源 `imagetools create` 构造全新 index，**不会继承**子清单/build 阶段的任何 annotation；不带此参数则 index 无版本注解，annotation-first `inspect_version` 必然落空（移动配对通道 minor/latest 同样带 annotation，sidecar 先行、main 随后、`verify_paired_moving_tag` 断言不变）
+- [x] 2.4 publish 步骤对每个被创建的 index 用 `imagetools inspect` 校验 `mediaType` 为 `application/vnd.oci.image.index.v1+json`（annotation 与 OCI index 绑定的前提），否则 fail-fast 并附"切换 OCI 媒体类型再发"错误
+- [x] 2.5 `inspect_version` 回退：优先读 index annotation `org.opencontainers.image.version`（由 2.3 显式写入保证存在），缺失时按 `[amd64, arm64]` 顺序取首个子清单读 label（替换现有硬编码 amd64 选择；旧单平台 tag 行为不变）
+- [x] 2.6 匿名拉取验证扩展：`docker pull` 后断言 manifest 为双架构 index（`docker buildx imagetools inspect` 或 `docker manifest inspect` 校验 amd64+arm64 子清单均存在）
+
+## 3. provenance 与策略脚本测试
+
+- [x] 3.1 两镜像的 `actions/attest` subject-digest 改为合并后回读的 index digest（2.2 产出），确认 provenance 对多架构 index 生成成功
+- [x] 3.2 **更新既有断言**：`scripts/release-policy.test.mjs` 现有 container.yml 钉死断言随 Option B 接线调整——attest `subject-name` 的 `needs.build.outputs.browser_image` 改指 `needs.resolve.outputs.browser_image`；checkout ref 断言（`steps.release.outputs.tag`）按 resolve job 内保留"Check out release source + id: release"步骤的布局校准；"决策先于首次变更"顺序断言若因 2.2 的 create-then-read 顺序变化需同步调整断言范围
+- [x] 3.3 `scripts/release-policy.test.mjs` **新增**断言：`needs.build.outputs.digest_amd64`/`digest_arm64`/`browser_digest_amd64`/`browser_digest_arm64` 四个接线全在；publish 步骤出现主镜像与 browser 两处双源 `imagetools create --tag ... @<amd64> @<arm64>` 且带 `--annotation index:org.opencontainers.image.version`；OCI 媒体类型校验步骤存在；`inspect_version` 注解优先路径存在；build-push `platforms: linux/${{ matrix.arch }}` 接线存在（防 1.5 回归）
+
+## 4. 文档与示例
+
+- [x] 4.1 `docs/USER.md` 与 `docs/USER.zh-CN.md`：两处容器平台行"仅 linux/amd64"改为"amd64 与 arm64"；桌面端"不发布 ARM64"句**保持原样不加括号**（桌面≠容器，不混淆）；在该段或独立 bullet 新增一句"容器镜像（`ghcr.io/klarkxy/opencode-go-mgr`）发布 `linux/amd64` 与 `linux/arm64`"明确与桌面端区分
+- [x] 4.2 `README.md` 镜像平台行改为 `linux/amd64, linux/arm64`
+- [x] 4.3 `compose.example.yaml` 删除两处 `platform: linux/amd64`；在文件顶部追加英文注释（与该文件既有英文注释一致）：`# On legacy Compose v1 or Podman-compose without manifest-list support, re-add "platform: linux/amd64" to pin amd64`
+- [x] 4.4 `AGENTS.md` 项目事实：container.yml 条目改为"构建并冒烟验证 `linux/amd64` 与 `linux/arm64` 镜像"
+- [x] 4.5 `docs/MAINTAINER.md` 与 `docs/MAINTAINER.zh-CN.md`：更新所有"仅 linux/amd64 / 不测试容器 ARM64"表述为双架构（发布矩阵、冒烟矩阵、平台覆盖章节），保持中英对等——spec 的"maintainer notes"要求覆盖此二文件
+
+## 5. 演练与验证（发布前执行）
+
+- [x] 5.1 推送前本地静态自查：`act` 不可用则以 YAML 语法 + actionlint（或等效人工审阅）核验 matrix/outputs/platforms 引用
+- [ ] 5.2 `workflow_dispatch` 用临时 tag（如 `v0.0.0-arm64-rehearsal-1`，非 stable、`publish_latest=false`）全流程演练：两架构构建+冒烟、合并发布、匿名拉取、provenance 全绿
+- [ ] 5.3 演练 tag 在 amd64 与 arm64 真机（或 CI 双架构 job）各 `docker pull` 一次，断言 `docker image inspect` 架构分别为 x86_64/aarch64；确认移动通道未被触碰（minor/latest digest 不变）
+- [ ] 5.4 删除演练 tag（保留至少 24h 给拉取缓存）；GHCR 包版本删除走 `gh api -X DELETE /user/packages/container/<package>/versions/<version_id>`（个人仓库）或 `/orgs/<org>/packages/container/<package>/versions/<version_id>`（组织仓库）——先用 `gh api /user/packages/container/<package>/versions`（或 org 路径）按 tag 查出 version id，再对主镜像与 `-browser` 两个包各删一次；包名即仓库名（opencode-go-mgr / opencode-go-mgr-browser）

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,32 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours
+
+# Per-operation guidance (optional)
+# Add advisory guidance for how apply and archive work should be conducted.
+# This is separate from artifact rules above.
+# Example:
+#   operations:
+#     apply:
+#       guidance:
+#         - Keep test summaries concise
+#     archive:
+#       guidance:
+#         - Summarize the archive outcome before finishing

--- a/scripts/release-policy.test.mjs
+++ b/scripts/release-policy.test.mjs
@@ -170,6 +170,10 @@ test("container publication checks out the release tag or an explicit source ref
     workflow,
     /ref: \$\{\{ inputs\.source_ref != '' && inputs\.source_ref \|\| format\('refs\/tags\/\{0\}', steps\.release\.outputs\.tag\) \}\}/,
   );
+  assert.match(
+    workflow,
+    /ref: \$\{\{ inputs\.source_ref != '' && inputs\.source_ref \|\| format\('refs\/tags\/\{0\}', needs\.resolve\.outputs\.tag\) \}\}/,
+  );
   assert.match(workflow, /git show-ref --verify --quiet "\$expected_ref"/);
   assert.match(workflow, /tag_commit=\$\(git rev-parse "\$expected_ref\^\{commit\}"\)/);
   assert.match(workflow, /node scripts\/release\.mjs --check/);
@@ -177,7 +181,55 @@ test("container publication checks out the release tag or an explicit source ref
   assert.match(workflow, /file: \.\/Dockerfile\.browser/);
   assert.match(workflow, /Smoke-test browser container and real Chromium/);
   assert.match(workflow, /provenance: mode=max[\s\S]*?sbom: true/);
-  assert.match(workflow, /subject-name: \$\{\{ needs\.build\.outputs\.browser_image \}\}/);
+  assert.match(workflow, /subject-name: \$\{\{ needs\.resolve\.outputs\.browser_image \}\}/);
+  assert.match(workflow, /subject-name: \$\{\{ needs\.resolve\.outputs\.image \}\}/);
+  assert.match(workflow, /subject-digest: \$\{\{ steps\.publish_tags\.outputs\.main_digest \}\}/);
+  assert.match(workflow, /subject-digest: \$\{\{ steps\.publish_tags\.outputs\.browser_digest \}\}/);
+});
+
+test("container publication builds each architecture natively and merges both digests", () => {
+  const workflow = readFileSync(
+    new URL("../.github/workflows/container.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(workflow, /arch: \[amd64, arm64\]/);
+  assert.match(workflow, /- arch: amd64\n\s+runs-on: ubuntu-24\.04\n/);
+  assert.match(workflow, /- arch: arm64\n\s+runs-on: ubuntu-24\.04-arm\n/);
+  assert.match(workflow, /runs-on: \$\{\{ matrix\.runs-on \}\}/);
+  assert.match(workflow, /timeout-minutes: 120/);
+  // Without parameterized platforms the arm64 leg would bake amd64 images through QEMU.
+  assert.match(workflow, /platforms: linux\/\$\{\{ matrix\.arch \}\}/);
+  assert.doesNotMatch(workflow, /platforms: linux\/amd64\b/);
+
+  assert.match(workflow, /browser_digest_amd64: \$\{\{ steps\.record_amd64\.outputs\.browser_digest \}\}/);
+  assert.match(workflow, /browser_digest_arm64: \$\{\{ steps\.record_arm64\.outputs\.browser_digest \}\}/);
+  assert.match(workflow, /digest_amd64: \$\{\{ steps\.record_amd64\.outputs\.digest \}\}/);
+  assert.match(workflow, /digest_arm64: \$\{\{ steps\.record_arm64\.outputs\.digest \}\}/);
+  assert.match(workflow, /MAIN_DIGEST_AMD64: \$\{\{ needs\.build\.outputs\.digest_amd64 \}\}/);
+  assert.match(workflow, /MAIN_DIGEST_ARM64: \$\{\{ needs\.build\.outputs\.digest_arm64 \}\}/);
+  assert.match(workflow, /BROWSER_DIGEST_AMD64: \$\{\{ needs\.build\.outputs\.browser_digest_amd64 \}\}/);
+  assert.match(workflow, /BROWSER_DIGEST_ARM64: \$\{\{ needs\.build\.outputs\.browser_digest_arm64 \}\}/);
+  assert.match(workflow, /if: matrix\.arch == 'amd64'/);
+  assert.match(workflow, /if: matrix\.arch == 'arm64'/);
+  assert.match(workflow, /cache-from: type=gha,scope=ocg-manager-linux-\$\{\{ matrix\.arch \}\}/);
+  assert.match(workflow, /cache-to: type=gha,mode=max,scope=ocg-manager-linux-\$\{\{ matrix\.arch \}\}/);
+  assert.match(workflow, /cache-from: type=gha,scope=ocg-browser-linux-\$\{\{ matrix\.arch \}\}/);
+  assert.match(workflow, /cache-to: type=gha,mode=max,scope=ocg-browser-linux-\$\{\{ matrix\.arch \}\}/);
+  assert.match(workflow, /CACHE_SCOPE=ocg-manager-linux-\$\{\{ matrix\.arch \}\}/);
+  assert.match(workflow, /CACHE_BROWSER_SCOPE=ocg-browser-linux-\$\{\{ matrix\.arch \}\}/);
+  assert.match(workflow, /SMOKE_IMAGE: ocg-manager:smoke-\$\{\{ github\.run_id \}\}-\$\{\{ matrix\.arch \}\}/);
+
+  const bake = readFileSync(
+    new URL("../docker-bake.hcl", import.meta.url),
+    "utf8",
+  );
+  assert.match(bake, /variable "CACHE_SCOPE" \{\s*\n\s*default = "ocg-manager-linux-amd64"/);
+  assert.match(bake, /variable "CACHE_BROWSER_SCOPE" \{\s*\n\s*default = "ocg-browser-linux-amd64"/);
+  assert.match(bake, /cache-from = \["type=gha,scope=\$\{CACHE_SCOPE\}"\]/);
+  assert.match(bake, /cache-from = \["type=gha,scope=\$\{CACHE_BROWSER_SCOPE\}"\]/);
+  // A platforms pin in the bake smoke targets would bake the wrong architecture
+  // on the arm64 leg; the native runner default is required.
+  assert.doesNotMatch(bake, /platforms\s*=/);
 });
 
 test("paired moving channels either converge at the candidate or remain aligned", () => {
@@ -211,25 +263,68 @@ test("container publication preflights paired moving channels before publishing 
   const publishStep = workflow.match(
     /- name: Publish tags without moving immutable references or rolling channels back[\s\S]*?(?=\n      - name: Generate signed GitHub provenance)/,
   )?.[0] ?? "";
+  const deriveBrowser = publishStep.indexOf('derive_candidate_index "$BROWSER_IMAGE"');
+  const deriveMain = publishStep.indexOf('derive_candidate_index "$MAIN_IMAGE"');
   const mainPreflight = publishStep.indexOf('preflight_immutable_image_tags "$MAIN_IMAGE" "$MAIN_DIGEST"');
   const browserPreflight = publishStep.indexOf('preflight_immutable_image_tags "$BROWSER_IMAGE" "$BROWSER_DIGEST"');
   const movingPreflight = publishStep.indexOf('preflight_moving_pair "$MINOR_CHANNEL"');
   const browserPublish = publishStep.indexOf('publish_immutable_image_tags "$BROWSER_IMAGE" "$BROWSER_DIGEST"');
   const mainPublish = publishStep.indexOf('publish_immutable_image_tags "$MAIN_IMAGE" "$MAIN_DIGEST"');
   const pairVerification = publishStep.indexOf('verify_paired_tag "$CANDIDATE_VERSION"');
+  const movingPublish = publishStep.indexOf('publish_moving_pair "$MINOR_CHANNEL"');
 
+  assert.ok(publishStep.match(/MAIN_DIGEST_AMD64 MAIN_DIGEST_ARM64 BROWSER_DIGEST_AMD64 BROWSER_DIGEST_ARM64/),
+    "all four architecture digests must be asserted non-empty before any publication");
+  assert.match(publishStep, /\[\[ -z "\$\{!arch_digest_var\}" \]\]/,
+    "the non-empty assertion must fail the step, not just enumerate the variables");
+  assert.ok(deriveBrowser >= 0 && deriveMain >= 0,
+    "both images must derive a merged multi-architecture index digest");
+  assert.ok(deriveBrowser < deriveMain,
+    "derive and publish the browser sidecar digest before the main image");
   assert.ok(mainPreflight >= 0 && browserPreflight >= 0, "both images must be preflighted");
   assert.ok(movingPreflight >= 0, "moving channels must be preflighted as a pair");
+  assert.ok(movingPreflight < deriveBrowser,
+    "paired moving-channel decisions need no candidate digest and must precede the first registry write");
   assert.ok(mainPreflight < browserPublish && browserPreflight < browserPublish,
-    "all immutable and moving-tag decisions must finish before the first tag write");
+    "all sha- tag decisions must finish before the first sha- tag write");
+  assert.ok(movingPreflight < movingPublish,
+    "moving-channel decisions must finish before the first moving-channel write");
   assert.ok(browserPublish < mainPublish,
     "publish the browser sidecar before exposing the matching main image");
   assert.ok(mainPublish < pairVerification,
     "verify both images together only after their publication sequence completes");
   assert.match(publishStep, /paired-channel/);
   assert.match(publishStep, /MOVING_EXPECTED_VERSIONS\["\$tag"\]=\$version/);
+  assert.match(
+    publishStep,
+    /EXPECTED_DIGESTS\["\$main_ref"\]=\$\(\[\[ "\$\{MOVING_DECISIONS\["\$main_ref"\]\}" == true \]\] && printf '%s' "\$MAIN_DIGEST" \|\| printf '%s' "\$\{MOVING_EXISTING_DIGESTS\["\$main_ref"\]\}"\)/,
+    "the main expected-digest expansion must stay a plain parameter expansion (stray characters corrupt kept digests)",
+  );
+  assert.match(
+    publishStep,
+    /EXPECTED_DIGESTS\["\$browser_ref"\]=\$\(\[\[ "\$\{MOVING_DECISIONS\["\$browser_ref"\]\}" == true \]\] && printf '%s' "\$BROWSER_DIGEST" \|\| printf '%s' "\$\{MOVING_EXISTING_DIGESTS\["\$browser_ref"\]\}"\)/,
+    "the browser expected-digest expansion must stay a plain parameter expansion (stray characters corrupt kept digests)",
+  );
+  assert.match(publishStep, /verify_merged_index "\$image" "\$ref" \|\| return 1/,
+    "derive_candidate_index must propagate verify_merged_index failures explicitly; errexit does not reach command substitutions");
   assert.match(publishStep, /verify_paired_moving_tag/);
   assert.match(publishStep, /verify_published_digest "\$BROWSER_IMAGE:\$tag"/);
+  assert.match(
+    publishStep,
+    /docker buildx imagetools create[\s\S]*?--annotation "index:org\.opencontainers\.image\.version=\$CANDIDATE_VERSION"[\s\S]*?--annotation "index:org\.opencontainers\.image\.revision=\$FULL_SHA"[\s\S]*?"\$image@\$amd64_digest" "\$image@\$arm64_digest"/,
+    "every tag must be assembled from both architecture digests with explicit index annotations",
+  );
+  assert.match(publishStep, /application\/vnd\.oci\.image\.index\.v1\+json/,
+    "published indexes must be verified as OCI image indexes");
+  assert.match(workflow, /oci-mediatypes=true/,
+    "build-push must lock in OCI media types so index annotations cannot be dropped");
+  assert.match(publishStep, /'\.annotations\."org\.opencontainers\.image\.revision" \/\/ empty'/,
+    "verify_merged_index must check the revision annotation as well as the version");
+  assert.match(publishStep, /inspect_version/);
+  assert.match(workflow, /'\.annotations\."org\.opencontainers\.image\.version" \/\/ empty'/,
+    "inspect_version must prefer the index annotation");
+  assert.match(workflow, /\.platform\.architecture == "arm64"/,
+    "inspect_version must fall back to arm64 children after amd64");
 });
 
 test("container publication requires anonymous exact-version pulls", () => {
@@ -244,6 +339,10 @@ test("container publication requires anonymous exact-version pulls", () => {
   assert.match(anonymousPull, /export DOCKER_CONFIG="\$anonymous_docker_config"/);
   assert.match(anonymousPull, /docker pull --quiet "\$MAIN_IMAGE:\$CANDIDATE_VERSION"/);
   assert.match(anonymousPull, /docker pull --quiet "\$BROWSER_IMAGE:\$CANDIDATE_VERSION"/);
+  assert.match(anonymousPull, /verify_public_index "\$MAIN_IMAGE:\$CANDIDATE_VERSION"/);
+  assert.match(anonymousPull, /verify_public_index "\$BROWSER_IMAGE:\$CANDIDATE_VERSION"/);
+  assert.match(anonymousPull, /"amd64,arm64"/,
+    "anonymous pulls must expose both architectures in the public manifest");
 });
 
 test("release preflight rejects a tag that does not match repository versions", () => {


### PR DESCRIPTION
## Summary

Adds native `linux/arm64` to the container release channel by converting `container.yml` to a per-architecture build matrix, merging both architectures into one OCI index per tag. Zero changes to `Dockerfile` / `Dockerfile.browser` / `release-policy.mjs`; desktop installers remain amd64/x64-only.

- **Build**: new `resolve` job produces release metadata (tag/version/minor/stable/publish_latest, contents:read); build job runs a matrix — amd64 on `ubuntu-24.04`, arm64 on `ubuntu-24.04-arm` (native runners, no QEMU for release artifacts). Each leg runs the full existing smoke suite (manager health/dashboard/auth; browser sidecar real-Chromium verification) natively, uses per-architecture GHA cache scopes (`*-amd64` strings unchanged so existing cache keeps hitting), arch-suffixed smoke resource names, and records only its own `digest_<arch>` / `browser_digest_<arch>` outputs. Build-push `platforms` is parameterized to `linux/${{ matrix.arch }}` and `docker-bake.hcl` smoke targets drop their hardcoded `platforms` pin — without that, the arm64 leg would bake amd64 images via QEMU.
- **Publish**: asserts all four architecture digests are non-empty, then derives the candidate index digest by two-source `imagetools create` on the version tag (sidecar first) with explicit `index:org.opencontainers.image.version/revision` annotations (multi-source create does not inherit source annotations). Every created tag is verified as an OCI image index with exactly the candidate child manifests, the version annotation, and the revision annotation. Paired moving-channel decisions run **before** the first registry write (they need no candidate digest); immutability refusals (including legacy single-platform tags and nondeterministic rebuilds) fail fast instead of overwriting. Anonymous-pull gate now asserts both architectures are present. Attestation subjects use the merged index digests.
- **Tests**: `scripts/release-policy.test.mjs` updated/extended — pins matrix wiring, `platforms: linux/${{ matrix.arch }}` (anti-QEMU regression), four digest outputs, two-source create with annotations, OCI mediaType check, annotation-first `inspect_version` with arm64 fallback, decision-before-write ordering, and the exact expected-digest expansions (a stray-character bug class caught during review).
- **Docs**: USER (en/zh), README, `compose.example.yaml` (drops both `platform:` pins, adds a legacy-Compose note), AGENTS.md, MAINTAINER (en/zh) — container images are amd64+arm64; desktop "no ARM64" wording kept but scoped to installers.
- OpenSpec change artifacts included under `openspec/changes/docker-arm64-release/`.

## Verification

- `node --test scripts/release-policy.test.mjs` 12/12; `node scripts/release.mjs --check` passes; all workflow `run:` blocks pass `bash -n`; YAML validated structurally (matrix/outputs/needs/permissions).
- Quality gate green on the fork: https://github.com/eveloki/opencode-go-mgr/actions/runs/32278008707 (Web 51s, Windows Tauri 4m57s, Rust 1m51s — first Rust attempt hit the 30-min job timeout on a hung `apt-get install`, unrelated; rerun green).
- Three rounds of adversarial review; two blocking findings (stray `]` corrupting kept browser channel digests; errexit being swallowed in command substitution inside `derive_candidate_index`) were fixed and pinned with tests.

## Before the first stable dual-arch release

Per the included design, the first real publication must go through the `workflow_dispatch` rehearsal with a temporary non-stable tag (tasks 5.2–5.4): full pipeline on a temp tag, `docker pull` architecture checks on both amd64 and arm64 hosts, confirm minor/latest untouched, then delete the rehearsal tags.