### PR TITLE
ci: publish linux/amd64 and linux/arm64 container images

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -27,14 +27,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build and verify GHCR images
+  resolve:
+    name: Resolve release metadata
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    timeout-minutes: 15
     outputs:
-      browser_digest: ${{ steps.push_browser.outputs.digest }}
       browser_image: ${{ steps.release.outputs.browser_image }}
-      digest: ${{ steps.push.outputs.digest }}
       full_sha: ${{ steps.commit.outputs.full_sha }}
       image: ${{ steps.release.outputs.image }}
       minor: ${{ steps.release.outputs.minor }}
@@ -45,17 +43,6 @@ jobs:
       version: ${{ steps.release.outputs.version }}
     permissions:
       contents: read
-      packages: write
-      attestations: write
-      id-token: write
-    env:
-      SMOKE_BROWSER_CONTAINER: ocg-browser-smoke-${{ github.run_id }}
-      SMOKE_BROWSER_IMAGE: ocg-browser:smoke-${{ github.run_id }}
-      SMOKE_BROWSER_PROFILE_VOLUME: ocg-browser-profile-smoke-${{ github.run_id }}
-      SMOKE_BROWSER_RUNTIME_VOLUME: ocg-browser-runtime-smoke-${{ github.run_id }}
-      SMOKE_IMAGE: ocg-manager:smoke-${{ github.run_id }}
-      SMOKE_CONTAINER: ocg-manager-smoke-${{ github.run_id }}
-      SMOKE_VOLUME: ocg-manager-smoke-${{ github.run_id }}
 
     steps:
       - name: Resolve release
@@ -139,6 +126,44 @@ jobs:
           echo "full_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "short_sha=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
 
+  build:
+    name: Build and verify GHCR images (${{ matrix.arch }})
+    needs: resolve
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 120
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runs-on: ubuntu-24.04
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
+    outputs:
+      browser_digest_amd64: ${{ steps.record_amd64.outputs.browser_digest }}
+      browser_digest_arm64: ${{ steps.record_arm64.outputs.browser_digest }}
+      digest_amd64: ${{ steps.record_amd64.outputs.digest }}
+      digest_arm64: ${{ steps.record_arm64.outputs.digest }}
+    permissions:
+      contents: read
+      packages: write
+    env:
+      SMOKE_BROWSER_CONTAINER: ocg-browser-smoke-${{ github.run_id }}-${{ matrix.arch }}
+      SMOKE_BROWSER_IMAGE: ocg-browser:smoke-${{ github.run_id }}-${{ matrix.arch }}
+      SMOKE_BROWSER_PROFILE_VOLUME: ocg-browser-profile-smoke-${{ github.run_id }}-${{ matrix.arch }}
+      SMOKE_BROWSER_RUNTIME_VOLUME: ocg-browser-runtime-smoke-${{ github.run_id }}-${{ matrix.arch }}
+      SMOKE_IMAGE: ocg-manager:smoke-${{ github.run_id }}-${{ matrix.arch }}
+      SMOKE_CONTAINER: ocg-manager-smoke-${{ github.run_id }}-${{ matrix.arch }}
+      SMOKE_VOLUME: ocg-manager-smoke-${{ github.run_id }}-${{ matrix.arch }}
+
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Same ref policy as the resolve job; both architecture legs build the identical commit.
+          ref: ${{ inputs.source_ref != '' && inputs.source_ref || format('refs/tags/{0}', needs.resolve.outputs.tag) }}
+          persist-credentials: false
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
@@ -154,6 +179,8 @@ jobs:
           vars: |
             SMOKE_IMAGE=${{ env.SMOKE_IMAGE }}
             SMOKE_BROWSER_IMAGE=${{ env.SMOKE_BROWSER_IMAGE }}
+            CACHE_SCOPE=ocg-manager-linux-${{ matrix.arch }}
+            CACHE_BROWSER_SCOPE=ocg-browser-linux-${{ matrix.arch }}
 
       - name: Smoke-test container
         shell: bash
@@ -328,29 +355,29 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ${{ steps.release.outputs.image }}
+          images: ${{ needs.resolve.outputs.image }}
           flavor: latest=false
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.release.outputs.tag }}
+            type=semver,pattern={{version}},value=${{ needs.resolve.outputs.tag }}
           labels: |
             org.opencontainers.image.title=OCG Manager
             org.opencontainers.image.description=OpenCode-Go multi-account local manager and gateway
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ steps.commit.outputs.full_sha }}
+            org.opencontainers.image.revision=${{ needs.resolve.outputs.full_sha }}
 
       - name: Generate browser image metadata
         id: meta_browser
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ${{ steps.release.outputs.browser_image }}
+          images: ${{ needs.resolve.outputs.browser_image }}
           flavor: latest=false
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.release.outputs.tag }}
+            type=semver,pattern={{version}},value=${{ needs.resolve.outputs.tag }}
           labels: |
             org.opencontainers.image.title=OCG Manager Browser Worker
             org.opencontainers.image.description=Isolated Chromium and noVNC sidecar for OCG Manager
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ steps.commit.outputs.full_sha }}
+            org.opencontainers.image.revision=${{ needs.resolve.outputs.full_sha }}
 
       - name: Build and push image
         id: push
@@ -358,14 +385,14 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
-          outputs: type=image,name=${{ steps.release.outputs.image }},push=true,push-by-digest=true,name-canonical=true
+          platforms: linux/${{ matrix.arch }}
+          outputs: type=image,name=${{ needs.resolve.outputs.image }},push=true,push-by-digest=true,name-canonical=true,oci-mediatypes=true
           labels: ${{ steps.meta.outputs.labels }}
           annotations: |
-            index:org.opencontainers.image.version=${{ steps.release.outputs.version }}
-            index:org.opencontainers.image.revision=${{ steps.commit.outputs.full_sha }}
-          cache-from: type=gha,scope=ocg-manager-linux-amd64
-          cache-to: type=gha,mode=max,scope=ocg-manager-linux-amd64
+            index:org.opencontainers.image.version=${{ needs.resolve.outputs.version }}
+            index:org.opencontainers.image.revision=${{ needs.resolve.outputs.full_sha }}
+          cache-from: type=gha,scope=ocg-manager-linux-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=ocg-manager-linux-${{ matrix.arch }}
           provenance: mode=max
           sbom: true
 
@@ -375,20 +402,38 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.browser
-          platforms: linux/amd64
-          outputs: type=image,name=${{ steps.release.outputs.browser_image }},push=true,push-by-digest=true,name-canonical=true
+          platforms: linux/${{ matrix.arch }}
+          outputs: type=image,name=${{ needs.resolve.outputs.browser_image }},push=true,push-by-digest=true,name-canonical=true,oci-mediatypes=true
           labels: ${{ steps.meta_browser.outputs.labels }}
           annotations: |
-            index:org.opencontainers.image.version=${{ steps.release.outputs.version }}
-            index:org.opencontainers.image.revision=${{ steps.commit.outputs.full_sha }}
-          cache-from: type=gha,scope=ocg-browser-linux-amd64
-          cache-to: type=gha,mode=max,scope=ocg-browser-linux-amd64
+            index:org.opencontainers.image.version=${{ needs.resolve.outputs.version }}
+            index:org.opencontainers.image.revision=${{ needs.resolve.outputs.full_sha }}
+          cache-from: type=gha,scope=ocg-browser-linux-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=ocg-browser-linux-${{ matrix.arch }}
           provenance: mode=max
           sbom: true
 
+      - name: Record amd64 digests
+        id: record_amd64
+        if: matrix.arch == 'amd64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "digest=${{ steps.push.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          echo "browser_digest=${{ steps.push_browser.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+      - name: Record arm64 digests
+        id: record_arm64
+        if: matrix.arch == 'arm64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "digest=${{ steps.push.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          echo "browser_digest=${{ steps.push_browser.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
   publish:
     name: Publish immutable and moving GHCR tags
-    needs: build
+    needs: [resolve, build]
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     concurrency:
@@ -417,19 +462,32 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish tags without moving immutable references or rolling channels back
+        id: publish_tags
         shell: bash
         env:
-          BROWSER_DIGEST: ${{ needs.build.outputs.browser_digest }}
-          BROWSER_IMAGE: ${{ needs.build.outputs.browser_image }}
-          CANDIDATE_VERSION: ${{ needs.build.outputs.version }}
-          MAIN_DIGEST: ${{ needs.build.outputs.digest }}
-          MAIN_IMAGE: ${{ needs.build.outputs.image }}
-          MINOR_CHANNEL: ${{ needs.build.outputs.minor }}
-          PUBLISH_LATEST: ${{ needs.build.outputs.publish_latest }}
-          SHORT_SHA: ${{ needs.build.outputs.short_sha }}
-          STABLE: ${{ needs.build.outputs.stable }}
+          BROWSER_DIGEST_AMD64: ${{ needs.build.outputs.browser_digest_amd64 }}
+          BROWSER_DIGEST_ARM64: ${{ needs.build.outputs.browser_digest_arm64 }}
+          BROWSER_IMAGE: ${{ needs.resolve.outputs.browser_image }}
+          CANDIDATE_VERSION: ${{ needs.resolve.outputs.version }}
+          FULL_SHA: ${{ needs.resolve.outputs.full_sha }}
+          MAIN_DIGEST_AMD64: ${{ needs.build.outputs.digest_amd64 }}
+          MAIN_DIGEST_ARM64: ${{ needs.build.outputs.digest_arm64 }}
+          MAIN_IMAGE: ${{ needs.resolve.outputs.image }}
+          MINOR_CHANNEL: ${{ needs.resolve.outputs.minor }}
+          PUBLISH_LATEST: ${{ needs.resolve.outputs.publish_latest }}
+          SHORT_SHA: ${{ needs.resolve.outputs.short_sha }}
+          STABLE: ${{ needs.resolve.outputs.stable }}
         run: |
           set -euo pipefail
+
+          for arch_digest_var in \
+            MAIN_DIGEST_AMD64 MAIN_DIGEST_ARM64 BROWSER_DIGEST_AMD64 BROWSER_DIGEST_ARM64; do
+            if [[ -z "${!arch_digest_var}" ]]; then
+              echo "Missing $arch_digest_var; both architecture legs must publish their digests." >&2
+              exit 1
+            fi
+          done
+
           inspect_digest() {
             local ref=$1
             local error_file="$RUNNER_TEMP/imagetools-inspect-error"
@@ -466,6 +524,11 @@ jobs:
             child_digest=$(jq -r '
               [.manifests[]? | select(.platform.os == "linux" and .platform.architecture == "amd64")][0].digest // empty
             ' <<<"$manifest")
+            if [[ -z "$child_digest" ]]; then
+              child_digest=$(jq -r '
+                [.manifests[]? | select(.platform.os == "linux" and .platform.architecture == "arm64")][0].digest // empty
+              ' <<<"$manifest")
+            fi
             if [[ -n "$child_digest" ]]; then
               image_ref="${ref%:*}@$child_digest"
             fi
@@ -487,13 +550,74 @@ jobs:
             fi
           }
 
+          arch_digests_for() {
+            local image=$1
+            if [[ "$image" == "$BROWSER_IMAGE" ]]; then
+              printf '%s %s' "$BROWSER_DIGEST_AMD64" "$BROWSER_DIGEST_ARM64"
+            else
+              printf '%s %s' "$MAIN_DIGEST_AMD64" "$MAIN_DIGEST_ARM64"
+            fi
+          }
+
+          merge_sources() {
+            local image=$1
+            local ref=$2
+            local amd64_digest
+            local arm64_digest
+            read -r amd64_digest arm64_digest <<<"$(arch_digests_for "$image")"
+            docker buildx imagetools create \
+              --tag "$ref" \
+              --annotation "index:org.opencontainers.image.version=$CANDIDATE_VERSION" \
+              --annotation "index:org.opencontainers.image.revision=$FULL_SHA" \
+              "$image@$amd64_digest" "$image@$arm64_digest"
+          }
+
+          verify_merged_index() {
+            local image=$1
+            local ref=$2
+            local amd64_digest
+            local arm64_digest
+            local annotation
+            local arch_manifests
+            local expected_manifests
+            local media_type
+            local raw
+            read -r amd64_digest arm64_digest <<<"$(arch_digests_for "$image")"
+            if ! raw=$(docker buildx imagetools inspect "$ref" --raw 2>"$RUNNER_TEMP/imagetools-index-error"); then
+              cat "$RUNNER_TEMP/imagetools-index-error" >&2
+              return 1
+            fi
+            arch_manifests=$(jq -r '[.manifests[]? | select(.platform.os == "linux") | .digest] | sort | join(",")' <<<"$raw")
+            expected_manifests=$(printf '%s\n%s\n' "$amd64_digest" "$arm64_digest" | LC_ALL=C sort | paste -sd, -)
+            if [[ "$arch_manifests" != "$expected_manifests" ]]; then
+              echo "Published index $ref does not merge exactly the candidate architecture manifests: $arch_manifests. An existing tag is immutable and cannot be replaced." >&2
+              return 1
+            fi
+            media_type=$(jq -r '.mediaType // empty' <<<"$raw")
+            if [[ "$media_type" != "application/vnd.oci.image.index.v1+json" ]]; then
+              echo "Published index $ref has media type '$media_type'; index annotations require an OCI image index. Rebuild with OCI media types before publishing." >&2
+              return 1
+            fi
+            annotation=$(jq -r '.annotations."org.opencontainers.image.version" // empty' <<<"$raw")
+            if [[ "$annotation" != "$CANDIDATE_VERSION" ]]; then
+              echo "Published index $ref carries version annotation '$annotation' instead of '$CANDIDATE_VERSION'." >&2
+              return 1
+            fi
+            local revision
+            revision=$(jq -r '.annotations."org.opencontainers.image.revision" // empty' <<<"$raw")
+            if [[ "$revision" != "$FULL_SHA" ]]; then
+              echo "Published index $ref carries revision annotation '$revision' instead of '$FULL_SHA'." >&2
+              return 1
+            fi
+          }
+
           check_immutable() {
             local image=$1
             local tag=$2
             local candidate_digest=$3
             local ref="$image:$tag"
             local existing
-            existing=$(inspect_digest "$ref")
+            existing=$(inspect_digest "$ref") || return 1
             node scripts/release-policy.mjs immutable-tag \
               --tag "$tag" \
               --candidate-digest "$candidate_digest" \
@@ -503,6 +627,7 @@ jobs:
           declare -A IMMUTABLE_DECISIONS
           declare -A MOVING_DECISIONS
           declare -A MOVING_CURRENT_VERSIONS
+          declare -A MOVING_EXISTING_DIGESTS
           declare -A EXPECTED_DIGESTS
           declare -A MOVING_EXPECTED_VERSIONS
 
@@ -555,9 +680,39 @@ jobs:
             MOVING_DECISIONS["$browser_ref"]=$browser_advance
             MOVING_CURRENT_VERSIONS["$main_ref"]=$main_current
             MOVING_CURRENT_VERSIONS["$browser_ref"]=$browser_current
-            EXPECTED_DIGESTS["$main_ref"]=$([[ "$main_advance" == true ]] && printf '%s' "$MAIN_DIGEST" || printf '%s' "$main_existing")
-            EXPECTED_DIGESTS["$browser_ref"]=$([[ "$browser_advance" == true ]] && printf '%s' "$BROWSER_DIGEST" || printf '%s' "$browser_existing")
+            MOVING_EXISTING_DIGESTS["$main_ref"]=$main_existing
+            MOVING_EXISTING_DIGESTS["$browser_ref"]=$browser_existing
             MOVING_EXPECTED_VERSIONS["$tag"]=$version
+          }
+
+          resolve_moving_expected_digests() {
+            local tag=$1
+            local main_ref="$MAIN_IMAGE:$tag"
+            local browser_ref="$BROWSER_IMAGE:$tag"
+            EXPECTED_DIGESTS["$main_ref"]=$([[ "${MOVING_DECISIONS["$main_ref"]}" == true ]] && printf '%s' "$MAIN_DIGEST" || printf '%s' "${MOVING_EXISTING_DIGESTS["$main_ref"]}")
+            EXPECTED_DIGESTS["$browser_ref"]=$([[ "${MOVING_DECISIONS["$browser_ref"]}" == true ]] && printf '%s' "$BROWSER_DIGEST" || printf '%s' "${MOVING_EXISTING_DIGESTS["$browser_ref"]}")
+          }
+
+          derive_candidate_index() {
+            local image=$1
+            local ref="$image:$CANDIDATE_VERSION"
+            local existing
+            existing=$(inspect_digest "$ref") || return 1
+            if [[ -z "$existing" ]]; then
+              merge_sources "$image" "$ref"
+              existing=$(inspect_digest "$ref")
+              if [[ -z "$existing" ]]; then
+                echo "Created $ref but could not read back its index digest." >&2
+                return 1
+              fi
+            fi
+            # buildx index assembly is deterministic (no timestamps or nonces), so an
+            # existing tag merging exactly these architecture manifests is the same
+            # digest a fresh create would produce; anything else must not be replaced.
+            # The explicit guard is required because errexit does not propagate into
+            # command substitutions and would silently continue with the old digest.
+            verify_merged_index "$image" "$ref" || return 1
+            printf '%s' "$existing"
           }
 
           publish_immutable() {
@@ -565,10 +720,10 @@ jobs:
             local tag=$2
             local candidate_digest=$3
             local decision=${IMMUTABLE_DECISIONS["$image:$tag"]}
-            local source_ref="$image@$candidate_digest"
             local ref="$image:$tag"
             if [[ "$decision" == create ]]; then
-              docker buildx imagetools create --tag "$ref" "$source_ref"
+              merge_sources "$image" "$ref"
+              verify_merged_index "$image" "$ref"
             else
               echo "Immutable tag $ref already resolves to the candidate digest; leaving it unchanged."
             fi
@@ -580,12 +735,12 @@ jobs:
             local tag=$2
             local candidate_digest=$3
             local key="$image:$tag"
-            local source_ref="$image@$candidate_digest"
             local ref="$key"
             local advance=${MOVING_DECISIONS["$key"]}
             local current_version=${MOVING_CURRENT_VERSIONS["$key"]}
             if [[ "$advance" == true ]]; then
-              docker buildx imagetools create --tag "$ref" "$source_ref"
+              merge_sources "$image" "$ref"
+              verify_merged_index "$image" "$ref"
               verify_published_digest "$ref" "$candidate_digest"
               echo "Advanced $ref from ${current_version:-none} to $CANDIDATE_VERSION."
             else
@@ -628,13 +783,28 @@ jobs:
             verify_paired_moving_tag "$tag"
           }
 
-          # Resolve both images completely before the first registry mutation.
-          preflight_immutable_image_tags "$MAIN_IMAGE" "$MAIN_DIGEST"
-          preflight_immutable_image_tags "$BROWSER_IMAGE" "$BROWSER_DIGEST"
+          # Decide every paired moving channel before the first registry mutation;
+          # these decisions compare remote channel versions and need no candidate
+          # digest.
           if [[ "$STABLE" == true ]]; then
             preflight_moving_pair "$MINOR_CHANNEL"
             if [[ "$PUBLISH_LATEST" == true ]]; then
               preflight_moving_pair latest
+            fi
+          fi
+
+          # Derive the merged multi-architecture index digests from the version tags
+          # (sidecar first) — the first registry writes — then finish the
+          # digest-dependent decisions before any further mutation.
+          BROWSER_DIGEST=$(derive_candidate_index "$BROWSER_IMAGE")
+          MAIN_DIGEST=$(derive_candidate_index "$MAIN_IMAGE")
+
+          preflight_immutable_image_tags "$MAIN_IMAGE" "$MAIN_DIGEST"
+          preflight_immutable_image_tags "$BROWSER_IMAGE" "$BROWSER_DIGEST"
+          if [[ "$STABLE" == true ]]; then
+            resolve_moving_expected_digests "$MINOR_CHANNEL"
+            if [[ "$PUBLISH_LATEST" == true ]]; then
+              resolve_moving_expected_digests latest
             fi
           fi
 
@@ -651,12 +821,15 @@ jobs:
             fi
           fi
 
+          echo "main_digest=$MAIN_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "browser_digest=$BROWSER_DIGEST" >> "$GITHUB_OUTPUT"
+
       - name: Verify public anonymous GHCR pulls
         shell: bash
         env:
-          BROWSER_IMAGE: ${{ needs.build.outputs.browser_image }}
-          CANDIDATE_VERSION: ${{ needs.build.outputs.version }}
-          MAIN_IMAGE: ${{ needs.build.outputs.image }}
+          BROWSER_IMAGE: ${{ needs.resolve.outputs.browser_image }}
+          CANDIDATE_VERSION: ${{ needs.resolve.outputs.version }}
+          MAIN_IMAGE: ${{ needs.resolve.outputs.image }}
         run: |
           set -euo pipefail
           anonymous_docker_config=$(mktemp -d)
@@ -665,16 +838,31 @@ jobs:
           docker pull --quiet "$MAIN_IMAGE:$CANDIDATE_VERSION"
           docker pull --quiet "$BROWSER_IMAGE:$CANDIDATE_VERSION"
 
+          verify_public_index() {
+            local ref=$1
+            local arches
+            arches=$(docker buildx imagetools inspect --raw "$ref" \
+              | jq -r '[.manifests[]? | select(.platform.os == "linux") | .platform.architecture] | sort | unique | join(",")')
+            if [[ "$arches" != "amd64,arm64" ]]; then
+              echo "Public manifest $ref does not expose both linux/amd64 and linux/arm64: $arches" >&2
+              exit 1
+            fi
+          }
+          verify_public_index "$MAIN_IMAGE:$CANDIDATE_VERSION"
+          verify_public_index "$BROWSER_IMAGE:$CANDIDATE_VERSION"
+          test "$(docker image inspect --format '{{.Architecture}}' "$MAIN_IMAGE:$CANDIDATE_VERSION")" = amd64
+          test "$(docker image inspect --format '{{.Architecture}}' "$BROWSER_IMAGE:$CANDIDATE_VERSION")" = amd64
+
       - name: Generate signed GitHub provenance
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
-          subject-name: ${{ needs.build.outputs.image }}
-          subject-digest: ${{ needs.build.outputs.digest }}
+          subject-name: ${{ needs.resolve.outputs.image }}
+          subject-digest: ${{ steps.publish_tags.outputs.main_digest }}
           push-to-registry: true
 
       - name: Generate signed GitHub provenance for browser image
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
-          subject-name: ${{ needs.build.outputs.browser_image }}
-          subject-digest: ${{ needs.build.outputs.browser_digest }}
+          subject-name: ${{ needs.resolve.outputs.browser_image }}
+          subject-digest: ${{ steps.publish_tags.outputs.browser_digest }}
           push-to-registry: true

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -160,9 +160,21 @@ jobs:
       - name: Check out release source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Same ref policy as the resolve job; both architecture legs build the identical commit.
-          ref: ${{ inputs.source_ref != '' && inputs.source_ref || format('refs/tags/{0}', needs.resolve.outputs.tag) }}
+          # Resolve is the only job allowed to interpret a mutable branch or tag.
+          ref: ${{ needs.resolve.outputs.full_sha }}
           persist-credentials: false
+
+      - name: Verify resolved release commit
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ needs.resolve.outputs.full_sha }}
+        run: |
+          set -euo pipefail
+          actual_sha=$(git rev-parse HEAD)
+          if [[ "$actual_sha" != "$EXPECTED_SHA" ]]; then
+            echo "Build checkout drifted from resolved commit: $actual_sha != $EXPECTED_SHA" >&2
+            exit 1
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -448,8 +460,22 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Run the helper paired with this trusted workflow definition. The
+          # release source itself was resolved once and built at full_sha.
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
+
+      - name: Verify trusted workflow commit
+        shell: bash
+        env:
+          EXPECTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          actual_sha=$(git rev-parse HEAD)
+          if [[ "$actual_sha" != "$EXPECTED_WORKFLOW_SHA" ]]; then
+            echo "Publish checkout drifted from trusted workflow commit: $actual_sha != $EXPECTED_WORKFLOW_SHA" >&2
+            exit 1
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -461,8 +487,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish tags without moving immutable references or rolling channels back
-        id: publish_tags
+      - name: Publish and verify immutable version and commit tags
+        id: immutable
         shell: bash
         env:
           BROWSER_DIGEST_AMD64: ${{ needs.build.outputs.browser_digest_amd64 }}
@@ -473,357 +499,8 @@ jobs:
           MAIN_DIGEST_AMD64: ${{ needs.build.outputs.digest_amd64 }}
           MAIN_DIGEST_ARM64: ${{ needs.build.outputs.digest_arm64 }}
           MAIN_IMAGE: ${{ needs.resolve.outputs.image }}
-          MINOR_CHANNEL: ${{ needs.resolve.outputs.minor }}
-          PUBLISH_LATEST: ${{ needs.resolve.outputs.publish_latest }}
           SHORT_SHA: ${{ needs.resolve.outputs.short_sha }}
-          STABLE: ${{ needs.resolve.outputs.stable }}
-        run: |
-          set -euo pipefail
-
-          for arch_digest_var in \
-            MAIN_DIGEST_AMD64 MAIN_DIGEST_ARM64 BROWSER_DIGEST_AMD64 BROWSER_DIGEST_ARM64; do
-            if [[ -z "${!arch_digest_var}" ]]; then
-              echo "Missing $arch_digest_var; both architecture legs must publish their digests." >&2
-              exit 1
-            fi
-          done
-
-          inspect_digest() {
-            local ref=$1
-            local error_file="$RUNNER_TEMP/imagetools-inspect-error"
-            local manifest
-            if manifest=$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest}}' 2>"$error_file"); then
-              jq -er '.digest' <<<"$manifest"
-              return
-            fi
-            if grep -Eqi 'manifest unknown|not found|no such manifest' "$error_file"; then
-              printf ''
-              return
-            fi
-            cat "$error_file" >&2
-            return 1
-          }
-
-          inspect_version() {
-            local ref=$1
-            local error_file="$RUNNER_TEMP/imagetools-version-error"
-            local child_digest
-            local image_ref=$ref
-            local labels
-            local manifest
-            local version
-            if ! manifest=$(docker buildx imagetools inspect "$ref" --raw 2>"$error_file"); then
-              cat "$error_file" >&2
-              return 1
-            fi
-            version=$(jq -r '.annotations."org.opencontainers.image.version" // empty' <<<"$manifest")
-            if [[ -n "$version" ]]; then
-              printf '%s' "$version"
-              return
-            fi
-            child_digest=$(jq -r '
-              [.manifests[]? | select(.platform.os == "linux" and .platform.architecture == "amd64")][0].digest // empty
-            ' <<<"$manifest")
-            if [[ -z "$child_digest" ]]; then
-              child_digest=$(jq -r '
-                [.manifests[]? | select(.platform.os == "linux" and .platform.architecture == "arm64")][0].digest // empty
-              ' <<<"$manifest")
-            fi
-            if [[ -n "$child_digest" ]]; then
-              image_ref="${ref%:*}@$child_digest"
-            fi
-            if ! labels=$(docker buildx imagetools inspect "$image_ref" --format '{{json .Image.Config.Labels}}' 2>"$error_file"); then
-              cat "$error_file" >&2
-              return 1
-            fi
-            jq -er '."org.opencontainers.image.version"' <<<"$labels"
-          }
-
-          verify_published_digest() {
-            local ref=$1
-            local candidate_digest=$2
-            local actual
-            actual=$(inspect_digest "$ref")
-            if [[ "$actual" != "$candidate_digest" ]]; then
-              echo "Published digest mismatch for $ref: $actual != $candidate_digest" >&2
-              exit 1
-            fi
-          }
-
-          arch_digests_for() {
-            local image=$1
-            if [[ "$image" == "$BROWSER_IMAGE" ]]; then
-              printf '%s %s' "$BROWSER_DIGEST_AMD64" "$BROWSER_DIGEST_ARM64"
-            else
-              printf '%s %s' "$MAIN_DIGEST_AMD64" "$MAIN_DIGEST_ARM64"
-            fi
-          }
-
-          merge_sources() {
-            local image=$1
-            local ref=$2
-            local amd64_digest
-            local arm64_digest
-            read -r amd64_digest arm64_digest <<<"$(arch_digests_for "$image")"
-            docker buildx imagetools create \
-              --tag "$ref" \
-              --annotation "index:org.opencontainers.image.version=$CANDIDATE_VERSION" \
-              --annotation "index:org.opencontainers.image.revision=$FULL_SHA" \
-              "$image@$amd64_digest" "$image@$arm64_digest"
-          }
-
-          verify_merged_index() {
-            local image=$1
-            local ref=$2
-            local amd64_digest
-            local arm64_digest
-            local annotation
-            local arch_manifests
-            local expected_manifests
-            local media_type
-            local raw
-            read -r amd64_digest arm64_digest <<<"$(arch_digests_for "$image")"
-            if ! raw=$(docker buildx imagetools inspect "$ref" --raw 2>"$RUNNER_TEMP/imagetools-index-error"); then
-              cat "$RUNNER_TEMP/imagetools-index-error" >&2
-              return 1
-            fi
-            arch_manifests=$(jq -r '[.manifests[]? | select(.platform.os == "linux") | .digest] | sort | join(",")' <<<"$raw")
-            expected_manifests=$(printf '%s\n%s\n' "$amd64_digest" "$arm64_digest" | LC_ALL=C sort | paste -sd, -)
-            if [[ "$arch_manifests" != "$expected_manifests" ]]; then
-              echo "Published index $ref does not merge exactly the candidate architecture manifests: $arch_manifests. An existing tag is immutable and cannot be replaced." >&2
-              return 1
-            fi
-            media_type=$(jq -r '.mediaType // empty' <<<"$raw")
-            if [[ "$media_type" != "application/vnd.oci.image.index.v1+json" ]]; then
-              echo "Published index $ref has media type '$media_type'; index annotations require an OCI image index. Rebuild with OCI media types before publishing." >&2
-              return 1
-            fi
-            annotation=$(jq -r '.annotations."org.opencontainers.image.version" // empty' <<<"$raw")
-            if [[ "$annotation" != "$CANDIDATE_VERSION" ]]; then
-              echo "Published index $ref carries version annotation '$annotation' instead of '$CANDIDATE_VERSION'." >&2
-              return 1
-            fi
-            local revision
-            revision=$(jq -r '.annotations."org.opencontainers.image.revision" // empty' <<<"$raw")
-            if [[ "$revision" != "$FULL_SHA" ]]; then
-              echo "Published index $ref carries revision annotation '$revision' instead of '$FULL_SHA'." >&2
-              return 1
-            fi
-          }
-
-          check_immutable() {
-            local image=$1
-            local tag=$2
-            local candidate_digest=$3
-            local ref="$image:$tag"
-            local existing
-            existing=$(inspect_digest "$ref") || return 1
-            node scripts/release-policy.mjs immutable-tag \
-              --tag "$tag" \
-              --candidate-digest "$candidate_digest" \
-              --existing-digest "$existing"
-          }
-
-          declare -A IMMUTABLE_DECISIONS
-          declare -A MOVING_DECISIONS
-          declare -A MOVING_CURRENT_VERSIONS
-          declare -A MOVING_EXISTING_DIGESTS
-          declare -A EXPECTED_DIGESTS
-          declare -A MOVING_EXPECTED_VERSIONS
-
-          preflight_immutable() {
-            local image=$1
-            local tag=$2
-            local candidate_digest=$3
-            local key="$image:$tag"
-            local decision
-            decision=$(check_immutable "$image" "$tag" "$candidate_digest")
-            IMMUTABLE_DECISIONS["$key"]=$decision
-            EXPECTED_DIGESTS["$key"]=$candidate_digest
-          }
-
-          preflight_immutable_image_tags() {
-            local image=$1
-            local candidate_digest=$2
-            preflight_immutable "$image" "$CANDIDATE_VERSION" "$candidate_digest"
-            preflight_immutable "$image" "sha-$SHORT_SHA" "$candidate_digest"
-          }
-
-          preflight_moving_pair() {
-            local tag=$1
-            local main_ref="$MAIN_IMAGE:$tag"
-            local browser_ref="$BROWSER_IMAGE:$tag"
-            local main_existing
-            local browser_existing
-            local main_current=
-            local browser_current=
-            local decision
-            local main_advance
-            local browser_advance
-            local version
-            main_existing=$(inspect_digest "$main_ref")
-            browser_existing=$(inspect_digest "$browser_ref")
-            if [[ -n "$main_existing" ]]; then
-              main_current=$(inspect_version "$main_ref")
-            fi
-            if [[ -n "$browser_existing" ]]; then
-              browser_current=$(inspect_version "$browser_ref")
-            fi
-            decision=$(node scripts/release-policy.mjs paired-channel \
-              --candidate "$CANDIDATE_VERSION" \
-              --main-current "$main_current" \
-              --browser-current "$browser_current")
-            main_advance=$(jq -er '.mainAdvance' <<<"$decision")
-            browser_advance=$(jq -er '.browserAdvance' <<<"$decision")
-            version=$(jq -er '.version' <<<"$decision")
-            MOVING_DECISIONS["$main_ref"]=$main_advance
-            MOVING_DECISIONS["$browser_ref"]=$browser_advance
-            MOVING_CURRENT_VERSIONS["$main_ref"]=$main_current
-            MOVING_CURRENT_VERSIONS["$browser_ref"]=$browser_current
-            MOVING_EXISTING_DIGESTS["$main_ref"]=$main_existing
-            MOVING_EXISTING_DIGESTS["$browser_ref"]=$browser_existing
-            MOVING_EXPECTED_VERSIONS["$tag"]=$version
-          }
-
-          resolve_moving_expected_digests() {
-            local tag=$1
-            local main_ref="$MAIN_IMAGE:$tag"
-            local browser_ref="$BROWSER_IMAGE:$tag"
-            EXPECTED_DIGESTS["$main_ref"]=$([[ "${MOVING_DECISIONS["$main_ref"]}" == true ]] && printf '%s' "$MAIN_DIGEST" || printf '%s' "${MOVING_EXISTING_DIGESTS["$main_ref"]}")
-            EXPECTED_DIGESTS["$browser_ref"]=$([[ "${MOVING_DECISIONS["$browser_ref"]}" == true ]] && printf '%s' "$BROWSER_DIGEST" || printf '%s' "${MOVING_EXISTING_DIGESTS["$browser_ref"]}")
-          }
-
-          derive_candidate_index() {
-            local image=$1
-            local ref="$image:$CANDIDATE_VERSION"
-            local existing
-            existing=$(inspect_digest "$ref") || return 1
-            if [[ -z "$existing" ]]; then
-              merge_sources "$image" "$ref"
-              existing=$(inspect_digest "$ref")
-              if [[ -z "$existing" ]]; then
-                echo "Created $ref but could not read back its index digest." >&2
-                return 1
-              fi
-            fi
-            # buildx index assembly is deterministic (no timestamps or nonces), so an
-            # existing tag merging exactly these architecture manifests is the same
-            # digest a fresh create would produce; anything else must not be replaced.
-            # The explicit guard is required because errexit does not propagate into
-            # command substitutions and would silently continue with the old digest.
-            verify_merged_index "$image" "$ref" || return 1
-            printf '%s' "$existing"
-          }
-
-          publish_immutable() {
-            local image=$1
-            local tag=$2
-            local candidate_digest=$3
-            local decision=${IMMUTABLE_DECISIONS["$image:$tag"]}
-            local ref="$image:$tag"
-            if [[ "$decision" == create ]]; then
-              merge_sources "$image" "$ref"
-              verify_merged_index "$image" "$ref"
-            else
-              echo "Immutable tag $ref already resolves to the candidate digest; leaving it unchanged."
-            fi
-            verify_published_digest "$ref" "$candidate_digest"
-          }
-
-          publish_moving() {
-            local image=$1
-            local tag=$2
-            local candidate_digest=$3
-            local key="$image:$tag"
-            local ref="$key"
-            local advance=${MOVING_DECISIONS["$key"]}
-            local current_version=${MOVING_CURRENT_VERSIONS["$key"]}
-            if [[ "$advance" == true ]]; then
-              merge_sources "$image" "$ref"
-              verify_merged_index "$image" "$ref"
-              verify_published_digest "$ref" "$candidate_digest"
-              echo "Advanced $ref from ${current_version:-none} to $CANDIDATE_VERSION."
-            else
-              echo "Kept $ref at newer or equal version $current_version."
-            fi
-          }
-
-          publish_immutable_image_tags() {
-            local image=$1
-            local candidate_digest=$2
-            publish_immutable "$image" "$CANDIDATE_VERSION" "$candidate_digest"
-            publish_immutable "$image" "sha-$SHORT_SHA" "$candidate_digest"
-          }
-
-          verify_paired_tag() {
-            local tag=$1
-            verify_published_digest "$MAIN_IMAGE:$tag" "${EXPECTED_DIGESTS["$MAIN_IMAGE:$tag"]}"
-            verify_published_digest "$BROWSER_IMAGE:$tag" "${EXPECTED_DIGESTS["$BROWSER_IMAGE:$tag"]}"
-          }
-
-          verify_paired_moving_tag() {
-            local tag=$1
-            local expected_version=${MOVING_EXPECTED_VERSIONS["$tag"]}
-            local main_version
-            local browser_version
-            verify_paired_tag "$tag"
-            main_version=$(inspect_version "$MAIN_IMAGE:$tag")
-            browser_version=$(inspect_version "$BROWSER_IMAGE:$tag")
-            if [[ "$main_version" != "$expected_version" || "$browser_version" != "$expected_version" ]]; then
-              echo "Paired channel $tag is split after publication: main=$main_version, browser=$browser_version, expected=$expected_version." >&2
-              exit 1
-            fi
-          }
-
-          publish_moving_pair() {
-            local tag=$1
-            # Publish the sidecar first so the matching dependency exists before the main image moves.
-            publish_moving "$BROWSER_IMAGE" "$tag" "$BROWSER_DIGEST"
-            publish_moving "$MAIN_IMAGE" "$tag" "$MAIN_DIGEST"
-            verify_paired_moving_tag "$tag"
-          }
-
-          # Decide every paired moving channel before the first registry mutation;
-          # these decisions compare remote channel versions and need no candidate
-          # digest.
-          if [[ "$STABLE" == true ]]; then
-            preflight_moving_pair "$MINOR_CHANNEL"
-            if [[ "$PUBLISH_LATEST" == true ]]; then
-              preflight_moving_pair latest
-            fi
-          fi
-
-          # Derive the merged multi-architecture index digests from the version tags
-          # (sidecar first) — the first registry writes — then finish the
-          # digest-dependent decisions before any further mutation.
-          BROWSER_DIGEST=$(derive_candidate_index "$BROWSER_IMAGE")
-          MAIN_DIGEST=$(derive_candidate_index "$MAIN_IMAGE")
-
-          preflight_immutable_image_tags "$MAIN_IMAGE" "$MAIN_DIGEST"
-          preflight_immutable_image_tags "$BROWSER_IMAGE" "$BROWSER_DIGEST"
-          if [[ "$STABLE" == true ]]; then
-            resolve_moving_expected_digests "$MINOR_CHANNEL"
-            if [[ "$PUBLISH_LATEST" == true ]]; then
-              resolve_moving_expected_digests latest
-            fi
-          fi
-
-          # A browser failure must not leave a main image available without its sidecar.
-          publish_immutable_image_tags "$BROWSER_IMAGE" "$BROWSER_DIGEST"
-          publish_immutable_image_tags "$MAIN_IMAGE" "$MAIN_DIGEST"
-
-          verify_paired_tag "$CANDIDATE_VERSION"
-          verify_paired_tag "sha-$SHORT_SHA"
-          if [[ "$STABLE" == true ]]; then
-            publish_moving_pair "$MINOR_CHANNEL"
-            if [[ "$PUBLISH_LATEST" == true ]]; then
-              publish_moving_pair latest
-            fi
-          fi
-
-          echo "main_digest=$MAIN_DIGEST" >> "$GITHUB_OUTPUT"
-          echo "browser_digest=$BROWSER_DIGEST" >> "$GITHUB_OUTPUT"
-
+        run: bash scripts/container-publish.sh publish-immutable
       - name: Verify public anonymous GHCR pulls
         shell: bash
         env:
@@ -857,12 +534,31 @@ jobs:
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-name: ${{ needs.resolve.outputs.image }}
-          subject-digest: ${{ steps.publish_tags.outputs.main_digest }}
+          subject-digest: ${{ steps.immutable.outputs.main_digest }}
           push-to-registry: true
 
       - name: Generate signed GitHub provenance for browser image
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-name: ${{ needs.resolve.outputs.browser_image }}
-          subject-digest: ${{ steps.publish_tags.outputs.browser_digest }}
+          subject-digest: ${{ steps.immutable.outputs.browser_digest }}
           push-to-registry: true
+
+      - name: Re-read and advance paired moving channels
+        shell: bash
+        env:
+          BROWSER_DIGEST: ${{ steps.immutable.outputs.browser_digest }}
+          BROWSER_DIGEST_AMD64: ${{ needs.build.outputs.browser_digest_amd64 }}
+          BROWSER_DIGEST_ARM64: ${{ needs.build.outputs.browser_digest_arm64 }}
+          BROWSER_IMAGE: ${{ needs.resolve.outputs.browser_image }}
+          CANDIDATE_VERSION: ${{ needs.resolve.outputs.version }}
+          FULL_SHA: ${{ needs.resolve.outputs.full_sha }}
+          MAIN_DIGEST: ${{ steps.immutable.outputs.main_digest }}
+          MAIN_DIGEST_AMD64: ${{ needs.build.outputs.digest_amd64 }}
+          MAIN_DIGEST_ARM64: ${{ needs.build.outputs.digest_arm64 }}
+          MAIN_IMAGE: ${{ needs.resolve.outputs.image }}
+          MINOR_CHANNEL: ${{ needs.resolve.outputs.minor }}
+          PUBLISH_LATEST: ${{ needs.resolve.outputs.publish_latest }}
+          SHORT_SHA: ${{ needs.resolve.outputs.short_sha }}
+          STABLE: ${{ needs.resolve.outputs.stable }}
+        run: bash scripts/container-publish.sh advance-moving

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 - 非回环监听使用单管理员登录。Docker 可通过 `OCG_ADMIN_USERNAME` 和 `OCG_ADMIN_PASSWORD` 首次初始化（两个必须同时设置，只设一个会启动报错）；未提供时由首个注册者创建管理员。
 - 设置页通过受保护的 `/dashboard/api/settings/check-update` 手动检查 GitHub 最新 Release。内置升级公钥的已安装桌面版可继续下载、校验签名并原位安装；开发构建、CLI、Docker 与尚未进入升级通道的旧版保留发布页/手动覆盖路径。
 - 价格表通过受保护的 `GET /dashboard/api/pricing`、`PUT /dashboard/api/pricing/multipliers`、`POST /dashboard/api/pricing/refresh` 管理；只在用户点击刷新时访问 `https://opencode.ai/docs/go/`，不得自动轮询。
-- 公开 GitHub Release 发布后，`.github/workflows/container.yml` 构建并冒烟验证 `linux/amd64` 镜像，发布到 `ghcr.io/klarkxy/opencode-go-mgr`。Compose 默认使用该镜像；本地源码构建需设置 `OCG_IMAGE=ocg-manager:local` 后执行 `docker compose up -d --build`。
+- 公开 GitHub Release 发布后，`.github/workflows/container.yml` 在 amd64（`ubuntu-24.04`）与 arm64（`ubuntu-24.04-arm`）原生 runner 上构建并冒烟验证 `linux/amd64` 与 `linux/arm64` 镜像，各架构按 digest 推送后合并为同一 tag 的多架构 OCI index，发布到 `ghcr.io/klarkxy/opencode-go-mgr`。Compose 默认使用该镜像；本地源码构建需设置 `OCG_IMAGE=ocg-manager:local` 后执行 `docker compose up -d --build`。
 - `.github/workflows/quality.yml` 在 PR / `main` 上拆成三个并行 job：Web 测试/类型/lint、Linux workspace Rust 测试/Clippy（占位 `dist/`，编译含 Tauri crate）、Windows Tauri 定向测试（占位 `dist/`，不跑 Vite）。`release.yml` 的手动候选（即使选择 tag ref）始终无签名且可只构建指定平台；只有 `v*` tag 的 push 事件才构建三平台并读取 repository signing secrets。tag push 视为单维护者的明确发布授权：工作流在校验附件集合与组装产物逐名一致（数量由产物推导，不硬编码）、升级签名、公钥连续性与 GitHub 服务端 digest 后自动公开同一个未变更 draft。
 - 容器固定以 UID/GID `10001` 运行并内置 `LICENSE`；Compose 透传可选的 `OCG_MANAGER_ENCRYPTION_KEY` 以支持显式密钥恢复，正常部署仍优先保留卷内 `.encryption-key`。
 - 下游访问根地址优先级：非空 `OCG_CLIENT_ROOT_URL` > SQLite 手工值 > 前端按生产 origin / 开发 Gateway 端口自动推导。环境变量覆盖只读且不得写回 SQLite。

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ Install, first-client checks for all five protocols, backup, and upgrades:
 
 ## Docker
 
-Public image: `ghcr.io/klarkxy/opencode-go-mgr` (`linux/amd64`, anonymous
-pull). Save [`compose.example.yaml`](compose.example.yaml) (also attached to
-each Release) as `compose.yaml` and run:
+Public image: `ghcr.io/klarkxy/opencode-go-mgr` (`linux/amd64, linux/arm64`,
+anonymous pull). Save [`compose.example.yaml`](compose.example.yaml) (also
+attached to each Release) as `compose.yaml` and run:
 
 ```bash
 docker compose pull

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -1,10 +1,12 @@
 # Pull-only Docker Compose example for OCG Manager v1.8.0.
 # Save this file as compose.yaml. Optionally create a neighboring .env file
 # with OCG_PORT, OCG_IMAGE, OCG_BROWSER_IMAGE, or the runtime variables below.
+# The images are multi-architecture (linux/amd64 and linux/arm64); Compose
+# picks the host's native variant. On legacy Compose v1 or Podman-compose
+# without manifest-list support, re-add "platform: linux/amd64" to pin amd64.
 services:
   ocg-manager:
     image: ${OCG_IMAGE:-ghcr.io/klarkxy/opencode-go-mgr:1.8.0}
-    platform: linux/amd64
     restart: unless-stopped
     environment:
       - OCG_ADMIN_USERNAME
@@ -41,7 +43,6 @@ services:
   browser:
     profiles: ["browser"]
     image: ${OCG_BROWSER_IMAGE:-ghcr.io/klarkxy/opencode-go-mgr-browser:1.8.0}
-    platform: linux/amd64
     restart: unless-stopped
     environment:
       - OCG_BROWSER_CONTROL_ADDR=0.0.0.0:9080

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,22 +6,30 @@ variable "SMOKE_BROWSER_IMAGE" {
   default = "ocg-browser:smoke"
 }
 
+variable "CACHE_SCOPE" {
+  default = "ocg-manager-linux-amd64"
+}
+
+variable "CACHE_BROWSER_SCOPE" {
+  default = "ocg-browser-linux-amd64"
+}
+
 group "smoke" {
   targets = ["manager-smoke", "browser-smoke"]
 }
 
+# No explicit platforms: each native CI runner builds and loads its own
+# architecture, which is what the per-architecture smoke suite expects.
 target "manager-smoke" {
   context = "."
   dockerfile = "Dockerfile"
-  platforms = ["linux/amd64"]
   tags = ["${SMOKE_IMAGE}"]
-  cache-from = ["type=gha,scope=ocg-manager-linux-amd64"]
+  cache-from = ["type=gha,scope=${CACHE_SCOPE}"]
 }
 
 target "browser-smoke" {
   context = "."
   dockerfile = "Dockerfile.browser"
-  platforms = ["linux/amd64"]
   tags = ["${SMOKE_BROWSER_IMAGE}"]
-  cache-from = ["type=gha,scope=ocg-browser-linux-amd64"]
+  cache-from = ["type=gha,scope=${CACHE_BROWSER_SCOPE}"]
 }

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -420,7 +420,7 @@ Each CLI archive contains its executable, `dist/`, and `LICENSE`. Do not ship
 the CLI executable alone: `serve` needs the sibling dashboard assets. Windows
 has no portable GUI artifact.
 
-The `linux/amd64` container is published separately as
+The `linux/amd64` and `linux/arm64` containers are published separately as
 `ghcr.io/klarkxy/opencode-go-mgr`; the GitHub Release contains the seven
 ordinary platform payloads, the extra macOS updater archive, four updater
 signatures, the pull-only Compose example, `latest.json`, and `SHA256SUMS`
@@ -650,8 +650,10 @@ clients cannot trust a release signed only by the replacement key.
 Release published by `release.yml` with `github.token` does not recursively
 start another workflow. After the signed tag pipeline publishes the Release,
 dispatch `container.yml` explicitly for that tag with `publish_latest=true`
-for a stable release. It checks out the release tag and, via `docker-bake.hcl`, builds both
-`linux/amd64` smoke images in parallel: the main
+for a stable release. It checks out the release tag and builds each
+architecture natively (amd64 on `ubuntu-24.04`, arm64 on `ubuntu-24.04-arm` —
+no QEMU emulation for release artifacts). Via `docker-bake.hcl`, each leg
+builds its own `linux/<arch>` smoke images in parallel: the main
 `ghcr.io/klarkxy/opencode-go-mgr` service and the
 `ghcr.io/klarkxy/opencode-go-mgr-browser` sidecar. The main smoke covers the
 dashboard, authentication, and license. The browser smoke starts Xvfb/noVNC
@@ -660,9 +662,12 @@ configuration, and no host-published port, then uses the token-protected
 control API to launch a real ordinary Chromium process with a persistent
 profile.
 
-Both verified results are pushed by digest without assigning a mutable name,
-then enter the repository-wide serialized tag queue. `X.Y.Z` and
-`sha-<12-character-commit>` are created only when absent; an existing tag is
+All verified results — two images per architecture — are pushed by digest
+without assigning a mutable name, then enter the repository-wide serialized
+tag queue. `X.Y.Z` and `sha-<12-character-commit>` are assembled by merging
+the two architecture digests into one multi-architecture OCI index (with
+explicit index version/revision annotations, since multi-source assembly
+does not inherit them) and are created only when absent; an existing tag is
 accepted only when its image's exact candidate digest already matches.
 Stable `X.Y` and opted-in `latest` are decided as a pair: the workflow either
 converges both image channels at the candidate or retains an already aligned
@@ -739,11 +744,12 @@ Pull requests automatically receive the three-job quality gate: frontend
 checks, Linux workspace Rust tests/Clippy (including the Tauri crate), and
 the Windows job that covers compilation and unit tests for Windows-only
 Tauri behavior. Native installer/package smokes remain manual release
-candidates or tag runs. The container workflow covers `linux/amd64` only
-and runs after a release is published or manually dispatched.
+candidates or tag runs. The container workflow covers `linux/amd64` and
+`linux/arm64` (each built and smoke-tested on its native runner) and runs
+after a release is published or manually dispatched.
 
 CI does not drive real desktop UI interactions or launch real Claude Desktop
-or Gemini CLI clients, and it does not test container ARM64, backup/restore,
+or Gemini CLI clients, and it does not test backup/restore,
 database downgrade, migration rollback, an upstream account, or a real
 gateway request. Rust tests cover Gemini/Claude Desktop routing,
 authentication, alias rewriting, non-stream conversion, and SSE event shapes,

--- a/docs/MAINTAINER.md
+++ b/docs/MAINTAINER.md
@@ -664,17 +664,30 @@ profile.
 
 All verified results — two images per architecture — are pushed by digest
 without assigning a mutable name, then enter the repository-wide serialized
-tag queue. `X.Y.Z` and `sha-<12-character-commit>` are assembled by merging
-the two architecture digests into one multi-architecture OCI index (with
-explicit index version/revision annotations, since multi-source assembly
-does not inherit them) and are created only when absent; an existing tag is
-accepted only when its image's exact candidate digest already matches.
-Stable `X.Y` and opted-in `latest` are decided as a pair: the workflow either
-converges both image channels at the candidate or retains an already aligned
-newer pair; it fails rather than silently retaining a split channel. Each
-image records an SPDX SBOM, BuildKit SLSA provenance, and GitHub signed
-provenance. `X.Y.Z` and `sha-*` are release-specific immutable tags; `X.Y`
-and `latest` are monotonic moving channels. The browser image is a GHCR
+tag queue. `resolve` is the only job that interprets the requested tag or
+optional `source_ref`; both native build legs check out that resolved full
+commit SHA and fail if `HEAD` differs. The publishing job uses the immutable
+`github.workflow_sha`, so the privileged registry helper always matches the
+reviewed workflow definition rather than executable files from a hotfix ref.
+
+Before writing a user-visible tag, the publishing job uses `docker buildx
+imagetools create --dry-run` to assemble each candidate OCI index locally. It
+hashes the exact returned JSON and validates both architecture children plus
+the index version/revision annotations. The main and browser `X.Y.Z` and
+`sha-<12-character-commit>` tags are all preflighted against those locally
+known digests before the browser tags, then the main tags, are created and
+verified. Existing immutable tags are accepted only at the exact candidate
+digest.
+
+Next, an empty Docker credential directory must anonymously pull both exact
+version tags, and GitHub must successfully publish signed provenance for both
+final index digests. Only then does the same serialized job re-read every
+remote moving channel and preflight the pair again. Stable `X.Y` and opted-in
+`latest` either converge both images at the candidate or retain an already
+aligned newer pair; the browser moves before the main image, and a split pair
+fails closed. Each architecture image also records an SPDX SBOM and BuildKit
+SLSA provenance. `X.Y.Z` and `sha-*` are release-specific immutable tags;
+`X.Y` and `latest` are monotonic moving channels. The browser image is a GHCR
 package, not a GitHub Release asset, so the native release keeps only the
 assembled GitHub attachments (the workflow compares that exact set, and the
 local verifier pins the current 15-file contract).
@@ -691,20 +704,27 @@ same digests, so the rerun completes the original publication without replacing
 artifacts. Do not treat the container distribution as complete until that rerun
 is green. Every later release must pass the anonymous gate on its first run.
 
+Before the first stable release on this dual-architecture path, publish a
+temporary SemVer prerelease and dispatch `container.yml` with
+`publish_latest=false`. Use that rehearsal to prove both native runners,
+package visibility, anonymous pulls, exact index children, and both signed
+provenance records. Do not use a stable tag as the rehearsal and do not advance
+`X.Y` or `latest` until the prerelease run is fully green.
+
 After tag publication the gate uses an empty Docker credential directory to
 pull both exact-version tags. A private or inaccessible package therefore fails
 `container.yml` instead of appearing as a successful public Compose dependency.
 
 A manual dispatch can backfill an existing release tag and must opt in before
-updating `latest`. The checkout uses the exact `refs/tags/<tag>` ref,
-verifies that HEAD resolves from that tag, and runs the repository version
-preflight before any image publication. Rebuilding different bytes for an
-existing full-version or `sha-*` tag fails instead of overwriting it; only an
-exact-digest replay is accepted. Its GitHub signing certificate identifies
-the workflow ref that triggered the dispatch, even though the build checks
-out the requested tag. Do not describe a historical manual backfill as
-tag-triggered provenance; normal `release.published` runs use the release tag
-context.
+updating `latest`. `resolve` checks out the exact `refs/tags/<tag>` ref (or the
+explicit hotfix `source_ref`), verifies the release tag and repository version,
+and emits one full SHA; no downstream job re-resolves the symbolic input.
+Rebuilding different bytes for an existing full-version or `sha-*` tag fails
+instead of overwriting it; only an exact-digest replay is accepted. Its GitHub
+signing certificate identifies the workflow ref that triggered the dispatch,
+even though the build checks out the resolved release commit. Do not describe
+a historical manual backfill as tag-triggered provenance; normal
+`release.published` runs use the release tag context.
 
 After publication, record the digest and verify both the OCI index and the
 GitHub attestation. Constrain verification to this signer workflow:

--- a/docs/MAINTAINER.zh-CN.md
+++ b/docs/MAINTAINER.zh-CN.md
@@ -356,7 +356,7 @@ SHA256SUMS
 每个 CLI 压缩包都包含可执行文件、`dist/`、`LICENSE`。**不要** 只发 CLI 可执
 行文件：`serve` 需要同级的 `dist/`。Windows 没有 portable GUI 安装包。
 
-`linux/amd64` 容器单独发布为 `ghcr.io/klarkxy/opencode-go-mgr`。GitHub Release
+`linux/amd64` 与 `linux/arm64` 容器单独发布为 `ghcr.io/klarkxy/opencode-go-mgr`。GitHub Release
 包含七份常规平台 payload、额外的 macOS 升级压缩包、四份升级签名、只拉取镜像
 的 Compose 示例、`latest.json` 与 `SHA256SUMS`（当前共 15 个附件）。本地验证器
 固定校验当前这 15 个文件，工作流同时要求 GitHub 附件的名称与数量和组装后的
@@ -532,16 +532,19 @@ closed。密钥轮换属于 break-glass 恢复，不是普通 secret 更新。�
 `.github/workflows/container.yml` 接受 Release 发布事件，但由 `release.yml` 使用
 `github.token` 公开的 Release 不会递归启动另一个工作流。签名 tag 流水线公开
 Release 后，稳定版必须对该 tag 显式触发 `container.yml`，并设置
-`publish_latest=true`。该工作流检出 Release tag，通过 `docker-bake.hcl` 并行构建
-两个 `linux/amd64` 冒烟镜像：主服务
+`publish_latest=true`。该工作流检出 Release tag，在各架构原生 runner 上构建
+（amd64 用 `ubuntu-24.04`、arm64 用 `ubuntu-24.04-arm`，发布产物不经 QEMU 模
+拟），并通过 `docker-bake.hcl` 并行构建本架构的冒烟镜像：主服务
 `ghcr.io/klarkxy/opencode-go-mgr` 与 Sidecar
 `ghcr.io/klarkxy/opencode-go-mgr-browser`。主镜像冒烟检查 Dashboard、鉴权和许可
 证；浏览器镜像在只读根文件系统、零 capability、Chromium 可用的 seccomp
 配置、无宿主机端口下启动 Xvfb/noVNC，并通过受 token 保护的控制 API 真正拉起
 普通 Chromium 与持久 Profile。
 
-两个镜像都先按 digest 推送而不分配可变名称，再进入仓库级串行标签队列。
-`X.Y.Z` 与 `sha-<12 位 commit>` 仅在不存在时创建；已存在时只有各自 digest 与
+全部验证通过的产物——每架构两个镜像——先按 digest 推送而不分配可变名称，再进入
+仓库级串行标签队列。`X.Y.Z` 与 `sha-<12 位 commit>` 由两个架构的 digest 合并为
+单一多架构 OCI index（显式携带 index 版本/revision 注解，多源组装不继承源注解），
+仅在不存在时创建；已存在时只有各自 digest 与
 候选完全相同才接受，否则失败。稳定版 `X.Y` 和选择更新的 `latest` 按镜像对整体
 决策：要么都收敛到候选版本，要么保留已经对齐的较新版本对；若通道仍会分裂，工作
 流会失败而不是静默保留。两个镜像各自记录 SPDX SBOM、BuildKit SLSA provenance
@@ -603,11 +606,12 @@ Docker 仍走直接/手动路径。
 
 PR 会自动运行三路并行质量门：前端检查、Linux workspace Rust 测试/Clippy（含
 Tauri crate），以及覆盖 Windows 专属 Tauri 行为编译和单测的 Windows job；原生
-安装包/打包冒烟仍只在手动候选或 tag 流程运行。容器工作流只覆盖 `linux/amd64`，
-并且只在 Release 发布后或手动触发时运行。
+安装包/打包冒烟仍只在手动候选或 tag 流程运行。容器工作流覆盖 `linux/amd64` 与
+`linux/arm64`（各自在原生 runner 上构建并冒烟），并且只在 Release 发布后或手动
+触发时运行。
 
-CI 不会操作真实桌面 UI，也不启动真实 Claude Desktop 或 Gemini CLI，不测试容
-器 ARM64、备份恢复、数据库降级、迁移回滚、真实上游账号或真实 Gateway 请求。
+CI 不会操作真实桌面 UI，也不启动真实 Claude Desktop 或 Gemini CLI，不测试备份
+恢复、数据库降级、迁移回滚、真实上游账号或真实 Gateway 请求。
 Rust 测试覆盖 Gemini/Claude Desktop 路由、鉴权、别名改写、非流式转换和 SSE 事
 件形状，但不能证明第三方客户端的新版本仍接受生成的配置。容器冒烟只检查 TCP
 健康、Dashboard HTML、auth status、镜像内许可证，以及未登录 settings 返回

--- a/docs/MAINTAINER.zh-CN.md
+++ b/docs/MAINTAINER.zh-CN.md
@@ -542,15 +542,25 @@ Release 后，稳定版必须对该 tag 显式触发 `container.yml`，并设置
 普通 Chromium 与持久 Profile。
 
 全部验证通过的产物——每架构两个镜像——先按 digest 推送而不分配可变名称，再进入
-仓库级串行标签队列。`X.Y.Z` 与 `sha-<12 位 commit>` 由两个架构的 digest 合并为
-单一多架构 OCI index（显式携带 index 版本/revision 注解，多源组装不继承源注解），
-仅在不存在时创建；已存在时只有各自 digest 与
-候选完全相同才接受，否则失败。稳定版 `X.Y` 和选择更新的 `latest` 按镜像对整体
-决策：要么都收敛到候选版本，要么保留已经对齐的较新版本对；若通道仍会分裂，工作
-流会失败而不是静默保留。两个镜像各自记录 SPDX SBOM、BuildKit SLSA provenance
-与 GitHub 签名 provenance。`X.Y.Z` 和 `sha-*` 是不可变发布标签；`X.Y` 与
-`latest` 是单调移动通道。浏览器镜像是 GHCR 包，不会增加 GitHub Release 附件；
-原生发布只保留组装后的 GitHub 附件（校验器从该集合推导名称/数量）。
+仓库级串行标签队列。只有 `resolve` job 可以解析请求 tag 或可选 `source_ref`；两个
+原生架构 build leg 都检出它输出的完整 commit SHA，并断言 `HEAD` 必须完全相同。
+publish job 则使用不可变的 `github.workflow_sha`，确保带 registry 写权限的 helper
+来自已审查的 workflow 定义，而不是热修 ref 中的可执行文件。
+
+写入用户可见标签前，publish job 先用 `docker buildx imagetools create --dry-run`
+在本地组装两个候选 OCI index，对返回的原始 JSON 求 digest，并校验两个架构 child
+及 index 的 version/revision 注解。主镜像与浏览器镜像的 `X.Y.Z`、`sha-<12 位
+commit>` 四个不可变标签必须全部以本地已知 digest 完成预检，之后才按浏览器在先、
+主镜像在后的顺序创建并验证；已存在标签只有 digest 与候选完全相同时才接受。
+
+随后工作流必须用空 Docker 凭据目录匿名拉取两个精确版本标签，并为两个最终 index
+digest 成功写入 GitHub 签名 provenance。只有这些步骤全绿，同一个串行 job 才会
+重新读取并预检远端移动通道。稳定版 `X.Y` 和选择更新的 `latest` 要么让两个镜像
+都收敛到候选版本，要么保留已经对齐的较新版本对；推进时浏览器在先、主镜像在后，
+若仍会分裂则 fail closed。每个架构镜像还记录 SPDX SBOM 与 BuildKit SLSA
+provenance。`X.Y.Z` 和 `sha-*` 是不可变发布标签；`X.Y` 与 `latest` 是单调移动
+通道。浏览器镜像是 GHCR 包，不会增加 GitHub Release 附件；原生发布只保留组装
+后的 GitHub 附件（校验器从该集合推导名称/数量）。
 
 Package 可见性独立于关联仓库管理，工作流不能依赖 repository token 代为改成
 公开；新的浏览器 package 在首次推送 digest 前也根本不存在。因此第一次创建该
@@ -561,17 +571,22 @@ package 的 `container.yml` 会先完成推送，再因 GitHub 默认的私有�
 原发布，不会替换产物。在重跑全绿前，不得把容器发布视为完成；之后每个 Release
 都必须在第一次运行时直接通过匿名门禁。
 
+首次走这条双架构链路发布稳定版之前，必须先发布一个临时 SemVer prerelease，并以
+`publish_latest=false` 触发 `container.yml`。这次 rehearsal 要证明两个原生
+runner、package 可见性、匿名拉取、index 精确 children 和两份签名 provenance
+全部成立。不得拿稳定 tag 当演练，也不得在预发布全绿之前推进 `X.Y` 或 `latest`。
+
 标签发布后，门禁使用空 Docker 凭证目录匿名拉取两个精确版本标签；package 若仍
 为私有或不可访问，`container.yml` 会失败，而不会伪装成可供公开 Compose 使用的
 成功发布。
 
-手动触发可回填已有 Release tag，且只有显式选择后才会更新 `latest`。工作流会
-显式检出 `refs/tags/<tag>`，验证 HEAD 确实由该 tag 解析得到，并在发布任何镜像
-前运行仓库版本预检。若重建内容与既有完整版本或 `sha-*` 标签的 digest 不同，
-会失败而不是覆盖；只接受完全相同 digest 的重放。它的 GitHub 签名证书记录发起
-dispatch 的 workflow ref，即使构建随后检出了指定 tag。因此不要把历史手动回填
-描述成“由该 tag 触发的 provenance”；正常 `release.published` 使用 Release
-tag 上下文。
+手动触发可回填已有 Release tag，且只有显式选择后才会更新 `latest`。`resolve`
+显式检出 `refs/tags/<tag>`（或明确指定的热修 `source_ref`），校验 Release tag 与
+仓库版本后输出唯一的完整 SHA；后续 job 不再解析符号 ref。若重建内容与既有完整
+版本或 `sha-*` 标签的 digest 不同，会失败而不是覆盖；只接受完全相同 digest 的
+重放。它的 GitHub 签名证书记录发起 dispatch 的 workflow ref，即使构建随后检出
+的是已解析的 release commit。因此不要把历史手动回填描述成“由该 tag 触发的
+provenance”；正常 `release.published` 使用 Release tag 上下文。
 
 发布后记录 digest，并同时核验 OCI index 与 GitHub attestation；验证时约束到
 本仓库的 signer workflow：

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -991,8 +991,9 @@ dashboard.
 ## Docker
 
 The public headless image can be pulled from GHCR without signing in. It is a
-Linux container and currently publishes `linux/amd64` only; there is no
-native ARM64 image. Each release also includes a pull-only
+Linux container publishing `linux/amd64` and `linux/arm64`; a plain
+`docker pull` selects the matching native variant on either architecture. Each
+release also includes a pull-only
 `compose.example.yaml`; save it as `compose.yaml` and optionally create a
 neighboring `.env`. The example pins its matching release by default, while
 `OCG_IMAGE` can override it. Alternatively, run the Compose commands from a
@@ -1271,9 +1272,11 @@ and browser profiles.
   `show_dock_icon` switch.
 - Windows / Linux ARM64 and 32-bit x86 builds are not published. RPM, Snap,
   app-store packages, Windows Authenticode signing, and Apple notarization
-  are not implemented. Updater-enabled installed desktop builds can install
-  signed releases from Settings; 1.4.1, development builds, the CLI, and
-  Docker use the direct/manual upgrade path.
+  are not implemented. That covers desktop installers only; the container
+  images (`ghcr.io/klarkxy/opencode-go-mgr` and its `-browser` sidecar)
+  publish `linux/amd64` and `linux/arm64`. Updater-enabled installed desktop
+  builds can install signed releases from Settings; 1.4.1, development
+  builds, the CLI, and Docker use the direct/manual upgrade path.
 
 ## Troubleshooting
 

--- a/docs/USER.zh-CN.md
+++ b/docs/USER.zh-CN.md
@@ -813,8 +813,9 @@ ocg-manager-cli
 
 ## Docker
 
-GHCR 上的公开无头镜像无需登录即可拉取。它是 Linux 容器，目前只发布
-`linux/amd64`，没有原生 ARM64 镜像。每个 Release 也会附带只拉取镜像的
+GHCR 上的公开无头镜像无需登录即可拉取。它是 Linux 容器，发布 `linux/amd64`
+与 `linux/arm64`；直接 `docker pull` 会在对应架构上自动选择原生变体。每个
+Release 也会附带只拉取镜像的
 `compose.example.yaml`；把它保存为 `compose.yaml`，并按需在同目录创建 `.env`。
 示例默认固定对应的发布版本，也可用 `OCG_IMAGE` 覆盖。或者在包含 `compose.yaml`
 与 `.env.example` 的仓库目录中运行（建议检出对应 Release tag）：
@@ -1044,7 +1045,9 @@ ocg.example.com {
 - macOS 桌面版可以在设置中隐藏 Dock 图标而只保留菜单栏图标；Windows、Linux、
   CLI 与 Docker 不暴露 `show_dock_icon` 开关。
 - 不发布 Windows / Linux ARM64、32 位 x86 构建；不支持 RPM、Snap、应用商店包、
-  Windows Authenticode 正式签名、Apple 公证。支持升级的已安装桌面版可在设置页
+  Windows Authenticode 正式签名、Apple 公证。该口径仅覆盖桌面安装包；容器镜像
+  （`ghcr.io/klarkxy/opencode-go-mgr` 及其 `-browser` 侧车）发布
+  `linux/amd64` 与 `linux/arm64`。支持升级的已安装桌面版可在设置页
   安装签名 Release；v1.4.1、开发构建、CLI、Docker 使用直接/手动升级路径。
 
 ## 常见问题

--- a/scripts/container-publish.sh
+++ b/scripts/container-publish.sh
@@ -1,0 +1,402 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+require_env() {
+  local name
+  for name in "$@"; do
+    if [[ -z "${!name:-}" ]]; then
+      echo "Missing required environment variable: $name" >&2
+      exit 1
+    fi
+  done
+}
+
+inspect_digest() {
+  local ref=$1
+  local error_file="$RUNNER_TEMP/imagetools-inspect-error"
+  local manifest
+  if manifest=$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest}}' 2>"$error_file"); then
+    jq -er '.digest' <<<"$manifest"
+    return
+  fi
+  if grep -Eqi 'manifest unknown|not found|no such manifest' "$error_file"; then
+    printf ''
+    return
+  fi
+  cat "$error_file" >&2
+  return 1
+}
+
+inspect_version() {
+  local ref=$1
+  local error_file="$RUNNER_TEMP/imagetools-version-error"
+  local child_digest
+  local image_ref=$ref
+  local labels
+  local manifest
+  local version
+  if ! manifest=$(docker buildx imagetools inspect "$ref" --raw 2>"$error_file"); then
+    cat "$error_file" >&2
+    return 1
+  fi
+  version=$(jq -r '.annotations."org.opencontainers.image.version" // empty' <<<"$manifest")
+  if [[ -n "$version" ]]; then
+    printf '%s' "$version"
+    return
+  fi
+  child_digest=$(jq -r '
+    [.manifests[]? | select(.platform.os == "linux" and .platform.architecture == "amd64")][0].digest // empty
+  ' <<<"$manifest")
+  if [[ -z "$child_digest" ]]; then
+    child_digest=$(jq -r '
+      [.manifests[]? | select(.platform.os == "linux" and .platform.architecture == "arm64")][0].digest // empty
+    ' <<<"$manifest")
+  fi
+  if [[ -n "$child_digest" ]]; then
+    image_ref="${ref%:*}@$child_digest"
+  fi
+  if ! labels=$(docker buildx imagetools inspect "$image_ref" --format '{{json .Image.Config.Labels}}' 2>"$error_file"); then
+    cat "$error_file" >&2
+    return 1
+  fi
+  jq -er '."org.opencontainers.image.version"' <<<"$labels"
+}
+
+arch_digests_for() {
+  local image=$1
+  if [[ "$image" == "$BROWSER_IMAGE" ]]; then
+    printf '%s %s' "$BROWSER_DIGEST_AMD64" "$BROWSER_DIGEST_ARM64"
+  else
+    printf '%s %s' "$MAIN_DIGEST_AMD64" "$MAIN_DIGEST_ARM64"
+  fi
+}
+
+manifest_digest() {
+  local manifest=$1
+  local checksum
+  if ! checksum=$(printf '%s' "$manifest" | sha256sum); then
+    echo "Failed to hash the dry-run candidate index." >&2
+    return 1
+  fi
+  checksum=${checksum%% *}
+  if [[ ! "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "Dry-run candidate index produced an invalid SHA-256 checksum: ${checksum:-<empty>}" >&2
+    return 1
+  fi
+  printf 'sha256:%s' "$checksum"
+}
+
+verify_index_json() {
+  local image=$1
+  local ref=$2
+  local raw=$3
+  local amd64_digest
+  local annotation
+  local arch_manifests
+  local arm64_digest
+  local expected_manifests
+  local media_type
+  local revision
+  read -r amd64_digest arm64_digest <<<"$(arch_digests_for "$image")"
+  jq -e . >/dev/null <<<"$raw"
+  arch_manifests=$(jq -r '[.manifests[]? | select(.platform.os == "linux") | .digest] | sort | join(",")' <<<"$raw")
+  expected_manifests=$(printf '%s\n%s\n' "$amd64_digest" "$arm64_digest" | LC_ALL=C sort | paste -sd, -)
+  if [[ "$arch_manifests" != "$expected_manifests" ]]; then
+    echo "Index $ref does not merge exactly the candidate architecture manifests: $arch_manifests." >&2
+    return 1
+  fi
+  media_type=$(jq -r '.mediaType // empty' <<<"$raw")
+  if [[ "$media_type" != "application/vnd.oci.image.index.v1+json" ]]; then
+    echo "Index $ref has media type '$media_type'; expected an OCI image index." >&2
+    return 1
+  fi
+  annotation=$(jq -r '.annotations."org.opencontainers.image.version" // empty' <<<"$raw")
+  if [[ "$annotation" != "$CANDIDATE_VERSION" ]]; then
+    echo "Index $ref carries version annotation '$annotation' instead of '$CANDIDATE_VERSION'." >&2
+    return 1
+  fi
+  revision=$(jq -r '.annotations."org.opencontainers.image.revision" // empty' <<<"$raw")
+  if [[ "$revision" != "$FULL_SHA" ]]; then
+    echo "Index $ref carries revision annotation '$revision' instead of '$FULL_SHA'." >&2
+    return 1
+  fi
+}
+
+candidate_manifest_for() {
+  local image=$1
+  local amd64_digest
+  local arm64_digest
+  read -r amd64_digest arm64_digest <<<"$(arch_digests_for "$image")"
+  docker buildx imagetools create \
+    --dry-run \
+    --progress quiet \
+    --annotation "index:org.opencontainers.image.version=$CANDIDATE_VERSION" \
+    --annotation "index:org.opencontainers.image.revision=$FULL_SHA" \
+    "$image@$amd64_digest" "$image@$arm64_digest"
+}
+
+verify_published_digest() {
+  local ref=$1
+  local candidate_digest=$2
+  local actual
+  actual=$(inspect_digest "$ref")
+  if [[ "$actual" != "$candidate_digest" ]]; then
+    echo "Published digest mismatch for $ref: $actual != $candidate_digest" >&2
+    return 1
+  fi
+}
+
+verify_remote_candidate_index() {
+  local image=$1
+  local ref=$2
+  local candidate_digest=$3
+  local raw
+  if ! raw=$(docker buildx imagetools inspect "$ref" --raw 2>"$RUNNER_TEMP/imagetools-index-error"); then
+    cat "$RUNNER_TEMP/imagetools-index-error" >&2
+    return 1
+  fi
+  verify_index_json "$image" "$ref" "$raw"
+  verify_published_digest "$ref" "$candidate_digest"
+}
+
+check_immutable() {
+  local image=$1
+  local tag=$2
+  local candidate_digest=$3
+  local ref="$image:$tag"
+  local existing
+  existing=$(inspect_digest "$ref") || return 1
+  node scripts/release-policy.mjs immutable-tag \
+    --tag "$tag" \
+    --candidate-digest "$candidate_digest" \
+    --existing-digest "$existing"
+}
+
+publish_candidate_index() {
+  local image=$1
+  local ref=$2
+  local amd64_digest
+  local arm64_digest
+  read -r amd64_digest arm64_digest <<<"$(arch_digests_for "$image")"
+  docker buildx imagetools create \
+    --progress quiet \
+    --tag "$ref" \
+    --annotation "index:org.opencontainers.image.version=$CANDIDATE_VERSION" \
+    --annotation "index:org.opencontainers.image.revision=$FULL_SHA" \
+    "$image@$amd64_digest" "$image@$arm64_digest"
+}
+
+publish_immutable_phase() {
+  require_env \
+    BROWSER_DIGEST_AMD64 BROWSER_DIGEST_ARM64 BROWSER_IMAGE CANDIDATE_VERSION FULL_SHA \
+    GITHUB_OUTPUT MAIN_DIGEST_AMD64 MAIN_DIGEST_ARM64 MAIN_IMAGE RUNNER_TEMP SHORT_SHA
+
+  local arch_digest_var
+  for arch_digest_var in \
+    MAIN_DIGEST_AMD64 MAIN_DIGEST_ARM64 BROWSER_DIGEST_AMD64 BROWSER_DIGEST_ARM64; do
+    if [[ ! "${!arch_digest_var}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+      echo "Invalid $arch_digest_var; both architecture legs must publish content digests." >&2
+      exit 1
+    fi
+  done
+
+  local browser_manifest
+  local main_manifest
+  local browser_digest
+  local main_digest
+  # Dry-run assembly is the only candidate-digest source. It reads the pushed
+  # architecture manifests but does not create a tag or other registry object.
+  browser_manifest=$(candidate_manifest_for "$BROWSER_IMAGE")
+  main_manifest=$(candidate_manifest_for "$MAIN_IMAGE")
+  verify_index_json "$BROWSER_IMAGE" "browser candidate dry-run" "$browser_manifest"
+  verify_index_json "$MAIN_IMAGE" "main candidate dry-run" "$main_manifest"
+  browser_digest=$(manifest_digest "$browser_manifest")
+  main_digest=$(manifest_digest "$main_manifest")
+
+  declare -A immutable_decisions
+  local candidate_digest
+  local image
+  local image_and_digest
+  local key
+  local tag
+  # Complete all four immutable-tag decisions before the first user-visible tag write.
+  for image_and_digest in \
+    "$MAIN_IMAGE $main_digest" \
+    "$BROWSER_IMAGE $browser_digest"; do
+    read -r image candidate_digest <<<"$image_and_digest"
+    for tag in "$CANDIDATE_VERSION" "sha-$SHORT_SHA"; do
+      key="$image:$tag"
+      immutable_decisions["$key"]=$(check_immutable "$image" "$tag" "$candidate_digest")
+    done
+  done
+
+  publish_immutable_image_tags() {
+    local image=$1
+    local candidate_digest=$2
+    local ref
+    local decision
+    local immutable_tag
+    for immutable_tag in "$CANDIDATE_VERSION" "sha-$SHORT_SHA"; do
+      ref="$image:$immutable_tag"
+      decision=${immutable_decisions["$ref"]}
+      if [[ "$decision" == create ]]; then
+        publish_candidate_index "$image" "$ref"
+      else
+        echo "Immutable tag $ref already resolves to the candidate digest; leaving it unchanged."
+      fi
+      verify_remote_candidate_index "$image" "$ref" "$candidate_digest"
+    done
+  }
+
+  # Publish the dependency first, then the main image, and verify both exact tags.
+  publish_immutable_image_tags "$BROWSER_IMAGE" "$browser_digest"
+  publish_immutable_image_tags "$MAIN_IMAGE" "$main_digest"
+  verify_published_digest "$BROWSER_IMAGE:$CANDIDATE_VERSION" "$browser_digest"
+  verify_published_digest "$MAIN_IMAGE:$CANDIDATE_VERSION" "$main_digest"
+  verify_published_digest "$BROWSER_IMAGE:sha-$SHORT_SHA" "$browser_digest"
+  verify_published_digest "$MAIN_IMAGE:sha-$SHORT_SHA" "$main_digest"
+
+  echo "main_digest=$main_digest" >>"$GITHUB_OUTPUT"
+  echo "browser_digest=$browser_digest" >>"$GITHUB_OUTPUT"
+}
+
+advance_moving_phase() {
+  require_env \
+    BROWSER_DIGEST BROWSER_DIGEST_AMD64 BROWSER_DIGEST_ARM64 BROWSER_IMAGE \
+    CANDIDATE_VERSION FULL_SHA MAIN_DIGEST MAIN_DIGEST_AMD64 MAIN_DIGEST_ARM64 \
+    MAIN_IMAGE PUBLISH_LATEST RUNNER_TEMP SHORT_SHA STABLE
+
+  if [[ "$STABLE" != true ]]; then
+    echo "Prerelease $CANDIDATE_VERSION has no moving container channels."
+    return
+  fi
+  require_env MINOR_CHANNEL
+
+  # This is a fresh post-attestation read. Moving-channel decisions never reuse
+  # registry state captured before immutable publication or public verification.
+  verify_remote_candidate_index "$BROWSER_IMAGE" "$BROWSER_IMAGE:$CANDIDATE_VERSION" "$BROWSER_DIGEST"
+  verify_remote_candidate_index "$MAIN_IMAGE" "$MAIN_IMAGE:$CANDIDATE_VERSION" "$MAIN_DIGEST"
+  verify_published_digest "$BROWSER_IMAGE:sha-$SHORT_SHA" "$BROWSER_DIGEST"
+  verify_published_digest "$MAIN_IMAGE:sha-$SHORT_SHA" "$MAIN_DIGEST"
+
+  declare -A moving_decisions
+  declare -A moving_current_versions
+  declare -A moving_existing_digests
+  declare -A moving_expected_versions
+  declare -A expected_digests
+
+  preflight_moving_pair() {
+    local tag=$1
+    local main_ref="$MAIN_IMAGE:$tag"
+    local browser_ref="$BROWSER_IMAGE:$tag"
+    local main_existing
+    local browser_existing
+    local main_current=
+    local browser_current=
+    local decision
+    local main_advance
+    local browser_advance
+    local version
+    main_existing=$(inspect_digest "$main_ref")
+    browser_existing=$(inspect_digest "$browser_ref")
+    if [[ -n "$main_existing" ]]; then
+      main_current=$(inspect_version "$main_ref")
+    fi
+    if [[ -n "$browser_existing" ]]; then
+      browser_current=$(inspect_version "$browser_ref")
+    fi
+    decision=$(node scripts/release-policy.mjs paired-channel \
+      --candidate "$CANDIDATE_VERSION" \
+      --main-current "$main_current" \
+      --browser-current "$browser_current")
+    main_advance=$(jq -er '.mainAdvance' <<<"$decision")
+    browser_advance=$(jq -er '.browserAdvance' <<<"$decision")
+    version=$(jq -er '.version' <<<"$decision")
+    moving_decisions["$main_ref"]=$main_advance
+    moving_decisions["$browser_ref"]=$browser_advance
+    moving_current_versions["$main_ref"]=$main_current
+    moving_current_versions["$browser_ref"]=$browser_current
+    moving_existing_digests["$main_ref"]=$main_existing
+    moving_existing_digests["$browser_ref"]=$browser_existing
+    moving_expected_versions["$tag"]=$version
+  }
+
+  resolve_moving_expected_digests() {
+    local tag=$1
+    local main_ref="$MAIN_IMAGE:$tag"
+    local browser_ref="$BROWSER_IMAGE:$tag"
+    expected_digests["$main_ref"]=$([[ "${moving_decisions["$main_ref"]}" == true ]] && printf '%s' "$MAIN_DIGEST" || printf '%s' "${moving_existing_digests["$main_ref"]}")
+    expected_digests["$browser_ref"]=$([[ "${moving_decisions["$browser_ref"]}" == true ]] && printf '%s' "$BROWSER_DIGEST" || printf '%s' "${moving_existing_digests["$browser_ref"]}")
+  }
+
+  preflight_moving_pair "$MINOR_CHANNEL"
+  if [[ "$PUBLISH_LATEST" == true ]]; then
+    preflight_moving_pair latest
+  fi
+  resolve_moving_expected_digests "$MINOR_CHANNEL"
+  if [[ "$PUBLISH_LATEST" == true ]]; then
+    resolve_moving_expected_digests latest
+  fi
+
+  publish_moving() {
+    local image=$1
+    local tag=$2
+    local candidate_digest=$3
+    local ref="$image:$tag"
+    local advance=${moving_decisions["$ref"]}
+    local current_version=${moving_current_versions["$ref"]}
+    if [[ "$advance" == true ]]; then
+      # A single index source is copied byte-for-byte, so the moving tag must
+      # resolve to the already published and attested candidate index digest.
+      docker buildx imagetools create --progress quiet --tag "$ref" "$image@$candidate_digest"
+      verify_published_digest "$ref" "$candidate_digest"
+      echo "Advanced $ref from ${current_version:-none} to $CANDIDATE_VERSION."
+    else
+      echo "Kept $ref at newer or equal version $current_version."
+    fi
+  }
+
+  verify_paired_moving_tag() {
+    local tag=$1
+    local main_ref="$MAIN_IMAGE:$tag"
+    local browser_ref="$BROWSER_IMAGE:$tag"
+    local expected_version=${moving_expected_versions["$tag"]}
+    local main_version
+    local browser_version
+    verify_published_digest "$main_ref" "${expected_digests["$main_ref"]}"
+    verify_published_digest "$browser_ref" "${expected_digests["$browser_ref"]}"
+    main_version=$(inspect_version "$main_ref")
+    browser_version=$(inspect_version "$browser_ref")
+    if [[ "$main_version" != "$expected_version" || "$browser_version" != "$expected_version" ]]; then
+      echo "Paired channel $tag is split after publication: main=$main_version, browser=$browser_version, expected=$expected_version." >&2
+      return 1
+    fi
+  }
+
+  publish_moving_pair() {
+    local tag=$1
+    # Publish the sidecar first so the matching dependency exists before the main image moves.
+    publish_moving "$BROWSER_IMAGE" "$tag" "$BROWSER_DIGEST"
+    publish_moving "$MAIN_IMAGE" "$tag" "$MAIN_DIGEST"
+    verify_paired_moving_tag "$tag"
+  }
+
+  publish_moving_pair "$MINOR_CHANNEL"
+  if [[ "$PUBLISH_LATEST" == true ]]; then
+    publish_moving_pair latest
+  fi
+}
+
+case "${1:-}" in
+  publish-immutable)
+    publish_immutable_phase
+    ;;
+  advance-moving)
+    advance_moving_phase
+    ;;
+  *)
+    echo "Usage: $0 publish-immutable|advance-moving" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/container-publish.test.mjs
+++ b/scripts/container-publish.test.mjs
@@ -1,0 +1,381 @@
+import assert from "node:assert/strict";
+import { appendFileSync, chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
+const helperPath = fileURLToPath(new URL("./container-publish.sh", import.meta.url));
+const bashPath = process.platform === "win32"
+  ? join(process.env.ProgramFiles ?? "C:\\Program Files", "Git", "bin", "bash.exe")
+  : "bash";
+
+const digests = {
+  browser: `sha256:${"b".repeat(64)}`,
+  browserAmd64: `sha256:${"c".repeat(64)}`,
+  browserArm64: `sha256:${"d".repeat(64)}`,
+  main: `sha256:${"a".repeat(64)}`,
+  mainAmd64: `sha256:${"e".repeat(64)}`,
+  mainArm64: `sha256:${"f".repeat(64)}`,
+};
+
+function toBashPath(path) {
+  if (process.platform !== "win32") return path;
+  const normalized = path.replaceAll("\\", "/");
+  return normalized.replace(/^([A-Za-z]):/, (_, drive) => `/${drive.toLowerCase()}`);
+}
+
+function writeExecutable(path, source) {
+  writeFileSync(path, source, "utf8");
+  chmodSync(path, 0o755);
+}
+
+const fakeDocker = String.raw`#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s|%s\n' "\${3:-docker}" "$*" >>"$CALL_LOG"
+
+raw_for_image() {
+  local image=$1
+  local amd64_digest
+  local arm64_digest
+  local test_image
+  if [[ "$image" == "$BROWSER_IMAGE" ]]; then
+    amd64_digest=$BROWSER_DIGEST_AMD64
+    arm64_digest=$BROWSER_DIGEST_ARM64
+    test_image=browser
+  else
+    amd64_digest=$MAIN_DIGEST_AMD64
+    arm64_digest=$MAIN_DIGEST_ARM64
+    test_image=main
+  fi
+  printf '{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"digest":"%s","platform":{"os":"linux","architecture":"amd64"}},{"digest":"%s","platform":{"os":"linux","architecture":"arm64"}}],"annotations":{"org.opencontainers.image.version":"%s","org.opencontainers.image.revision":"%s"},"testImage":"%s"}' \
+    "$amd64_digest" "$arm64_digest" "$CANDIDATE_VERSION" "$FULL_SHA" "$test_image"
+}
+
+state_file_for() {
+  local ref=$1
+  local key
+  key=$(printf '%s' "$ref" | tr '/:@' '____')
+  printf '%s/%s' "$FAKE_STATE_DIR" "$key"
+}
+
+if [[ "\${1:-}" != buildx || "\${2:-}" != imagetools ]]; then
+  echo "unexpected docker command: $*" >&2
+  exit 90
+fi
+
+case "\${3:-}" in
+  inspect)
+    ref=$4
+    state_file=$(state_file_for "$ref")
+    if [[ ! -f "$state_file" ]]; then
+      echo "manifest unknown: $ref" >&2
+      exit 1
+    fi
+    digest=$(<"$state_file")
+    if [[ "$*" == *"--raw"* ]]; then
+      if [[ "$ref" == "$BROWSER_IMAGE"* ]]; then
+        raw_for_image "$BROWSER_IMAGE"
+      else
+        raw_for_image "$MAIN_IMAGE"
+      fi
+    elif [[ "$*" == *".Image.Config.Labels"* ]]; then
+      printf '{"org.opencontainers.image.version":"%s"}' "$CANDIDATE_VERSION"
+    else
+      printf '{"digest":"%s"}' "$digest"
+    fi
+    ;;
+  create)
+    if [[ "\${FAIL_DOCKER_DRY_RUN:-0}" == 1 && "$*" == *"--dry-run"* ]]; then
+      echo "forced docker dry-run failure" >&2
+      exit 71
+    fi
+    image=$MAIN_IMAGE
+    if [[ "$*" == *"$BROWSER_IMAGE@"* || "$*" == *"--tag $BROWSER_IMAGE:"* ]]; then
+      image=$BROWSER_IMAGE
+      digest=$BROWSER_CANDIDATE_DIGEST
+    else
+      digest=$MAIN_CANDIDATE_DIGEST
+    fi
+    if [[ "$*" == *"--dry-run"* ]]; then
+      raw_for_image "$image"
+      exit 0
+    fi
+    tag=
+    previous=
+    for argument in "$@"; do
+      if [[ "$previous" == --tag ]]; then
+        tag=$argument
+        break
+      fi
+      previous=$argument
+    done
+    if [[ -z "$tag" ]]; then
+      echo "create call did not include --tag: $*" >&2
+      exit 72
+    fi
+    printf '%s' "$digest" >"$(state_file_for "$tag")"
+    ;;
+  *)
+    echo "unexpected imagetools command: $*" >&2
+    exit 91
+    ;;
+esac
+`.replaceAll("\\${", "${");
+
+const fakeJq = String.raw`#!/usr/bin/env bash
+set -euo pipefail
+input=$(cat)
+if [[ "\${FAIL_JQ:-0}" == 1 ]]; then
+  echo "forced jq failure" >&2
+  exit 73
+fi
+arguments="$*"
+if [[ "$arguments" == *"manifests[]?"* && "$arguments" == *"sort | join"* ]]; then
+  if [[ "$input" == *'"testImage":"browser"'* ]]; then
+    printf '%s\n%s\n' "$BROWSER_DIGEST_AMD64" "$BROWSER_DIGEST_ARM64" | LC_ALL=C sort | paste -sd, -
+  else
+    printf '%s\n%s\n' "$MAIN_DIGEST_AMD64" "$MAIN_DIGEST_ARM64" | LC_ALL=C sort | paste -sd, -
+  fi
+elif [[ "$arguments" == *"org.opencontainers.image.revision"* ]]; then
+  printf '%s\n' "$FULL_SHA"
+elif [[ "$arguments" == *"org.opencontainers.image.version"* ]]; then
+  printf '%s\n' "$CANDIDATE_VERSION"
+elif [[ "$arguments" == *"mediaType // empty"* ]]; then
+  printf '%s\n' 'application/vnd.oci.image.index.v1+json'
+elif [[ "$arguments" == *".mainAdvance"* || "$arguments" == *".browserAdvance"* ]]; then
+  printf '%s\n' true
+elif [[ "$arguments" == *".version"* ]]; then
+  printf '%s\n' "$CANDIDATE_VERSION"
+elif [[ "$arguments" == *".digest"* ]]; then
+  printf '%s\n' "$input" | sed -n 's/.*"digest":"\([^"]*\)".*/\1/p'
+elif [[ "$arguments" == *"-e ."* ]]; then
+  [[ -n "$input" ]]
+else
+  echo "unexpected jq invocation: $arguments" >&2
+  exit 74
+fi
+`.replaceAll("\\${", "${");
+
+const fakeNode = String.raw`#!/usr/bin/env bash
+set -euo pipefail
+printf 'NODE|%s\n' "$*" >>"$CALL_LOG"
+if [[ "\${1:-}" != scripts/release-policy.mjs ]]; then
+  echo "unexpected node invocation: $*" >&2
+  exit 75
+fi
+case "\${2:-}" in
+  immutable-tag)
+    count_file="$FAKE_STATE_DIR/immutable-count"
+    count=0
+    if [[ -f "$count_file" ]]; then
+      count=$(<"$count_file")
+    fi
+    count=$((count + 1))
+    printf '%s' "$count" >"$count_file"
+    if [[ "\${FAIL_IMMUTABLE_CALL:-0}" == "$count" ]]; then
+      echo "forced immutable preflight failure $count" >&2
+      exit 76
+    fi
+    printf '%s' create
+    ;;
+  paired-channel)
+    printf '{"mainAdvance":true,"browserAdvance":true,"version":"%s"}' "$CANDIDATE_VERSION"
+    ;;
+  *)
+    echo "unexpected release policy command: $*" >&2
+    exit 77
+    ;;
+esac
+`.replaceAll("\\${", "${");
+
+const fakeSha256sum = String.raw`#!/usr/bin/env bash
+set -euo pipefail
+input=$(cat)
+if [[ "\${FAIL_SHA256SUM:-0}" == 1 ]]; then
+  echo "forced sha256sum failure" >&2
+  exit 78
+fi
+if [[ "$input" == *'"testImage":"browser"'* ]]; then
+  printf '%s  -\n' "\${BROWSER_CANDIDATE_DIGEST#sha256:}"
+else
+  printf '%s  -\n' "\${MAIN_CANDIDATE_DIGEST#sha256:}"
+fi
+`.replaceAll("\\${", "${");
+
+function createSandbox(t) {
+  const root = mkdtempSync(join(tmpdir(), "ocg-container-publish-"));
+  const fakeBin = join(root, "bin");
+  const state = join(root, "state");
+  const runnerTemp = join(root, "runner");
+  const output = join(root, "github-output");
+  const log = join(root, "calls.log");
+  mkdirSync(fakeBin);
+  mkdirSync(state);
+  mkdirSync(runnerTemp);
+  writeExecutable(join(fakeBin, "docker"), fakeDocker);
+  writeExecutable(join(fakeBin, "jq"), fakeJq);
+  writeExecutable(join(fakeBin, "node"), fakeNode);
+  writeExecutable(join(fakeBin, "sha256sum"), fakeSha256sum);
+  t.after(() => rmSync(root, { force: true, recursive: true }));
+
+  const env = {
+    ...process.env,
+    BROWSER_CANDIDATE_DIGEST: digests.browser,
+    BROWSER_DIGEST_AMD64: digests.browserAmd64,
+    BROWSER_DIGEST_ARM64: digests.browserArm64,
+    BROWSER_IMAGE: "ghcr.io/example/ocg-manager-browser",
+    CALL_LOG: toBashPath(log),
+    CANDIDATE_VERSION: "1.8.0",
+    FAKE_BIN: toBashPath(fakeBin),
+    FAKE_STATE_DIR: toBashPath(state),
+    FULL_SHA: "1234567890abcdef1234567890abcdef12345678",
+    GITHUB_OUTPUT: toBashPath(output),
+    HELPER: toBashPath(helperPath),
+    MAIN_CANDIDATE_DIGEST: digests.main,
+    MAIN_DIGEST_AMD64: digests.mainAmd64,
+    MAIN_DIGEST_ARM64: digests.mainArm64,
+    MAIN_IMAGE: "ghcr.io/example/ocg-manager",
+    MINOR_CHANNEL: "1.8",
+    PHASE: "publish-immutable",
+    PUBLISH_LATEST: "true",
+    RUNNER_TEMP: toBashPath(runnerTemp),
+    SHORT_SHA: "1234567890ab",
+    STABLE: "true",
+  };
+
+  return {
+    appendLog(value) {
+      appendFileSync(log, value, "utf8");
+    },
+    log() {
+      return readFileSync(log, "utf8");
+    },
+    output() {
+      return readFileSync(output, "utf8");
+    },
+    run(phase, overrides = {}) {
+      return spawnSync(
+        bashPath,
+        ["-c", 'export PATH="$FAKE_BIN:$PATH"; bash "$HELPER" "$PHASE"'],
+        {
+          cwd: repositoryRoot,
+          encoding: "utf8",
+          env: { ...env, ...overrides, PHASE: phase },
+          timeout: 60_000,
+        },
+      );
+    },
+  };
+}
+
+function diagnostic(result) {
+  return `status=${result.status}\nstdout=${result.stdout}\nstderr=${result.stderr}`;
+}
+
+function createLines(log) {
+  return log.split(/\r?\n/).filter((line) => line.startsWith("create|") && line.includes("--tag"));
+}
+
+function comparableCreateArguments(line) {
+  const tokens = line.slice(line.indexOf("|") + 1).split(" ");
+  const annotations = [];
+  const sources = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (tokens[index] === "--annotation") annotations.push(tokens[index + 1]);
+    if (tokens[index].includes("@sha256:")) sources.push(tokens[index]);
+  }
+  return { annotations, sources };
+}
+
+test("any immutable preflight failure exits before every tag create", async (t) => {
+  for (let failedCall = 1; failedCall <= 4; failedCall += 1) {
+    await t.test(`immutable preflight ${failedCall}`, (t) => {
+      const sandbox = createSandbox(t);
+      const result = sandbox.run("publish-immutable", { FAIL_IMMUTABLE_CALL: String(failedCall) });
+      assert.notEqual(result.status, 0, diagnostic(result));
+      assert.equal(createLines(sandbox.log()).length, 0, sandbox.log());
+    });
+  }
+});
+
+test("immutable publication reuses dry-run sources and annotations and publishes browser first", (t) => {
+  const sandbox = createSandbox(t);
+  const result = sandbox.run("publish-immutable");
+  assert.equal(result.status, 0, `${diagnostic(result)}\n${sandbox.log()}`);
+
+  const lines = sandbox.log().split(/\r?\n/);
+  const dryRuns = lines.filter((line) => line.startsWith("create|") && line.includes("--dry-run"));
+  const creates = createLines(sandbox.log());
+  assert.equal(dryRuns.length, 2, sandbox.log());
+  assert.deepEqual(
+    creates.map((line) => /--tag ([^ ]+)/.exec(line)?.[1]),
+    [
+      "ghcr.io/example/ocg-manager-browser:1.8.0",
+      "ghcr.io/example/ocg-manager-browser:sha-1234567890ab",
+      "ghcr.io/example/ocg-manager:1.8.0",
+      "ghcr.io/example/ocg-manager:sha-1234567890ab",
+    ],
+  );
+  for (const create of creates) {
+    const image = create.includes("ocg-manager-browser") ? "ocg-manager-browser" : "ocg-manager@";
+    const dryRun = dryRuns.find((line) => line.includes(image));
+    assert.ok(dryRun, `missing dry-run for ${create}`);
+    assert.deepEqual(comparableCreateArguments(create), comparableCreateArguments(dryRun));
+  }
+  assert.match(sandbox.output(), new RegExp(`main_digest=${digests.main}`));
+  assert.match(sandbox.output(), new RegExp(`browser_digest=${digests.browser}`));
+});
+
+test("docker, jq, node, and command-substitution failures remain non-zero", async (t) => {
+  const scenarios = [
+    ["docker", { FAIL_DOCKER_DRY_RUN: "1" }],
+    ["jq", { FAIL_JQ: "1" }],
+    ["node", { FAIL_IMMUTABLE_CALL: "1" }],
+    ["command substitution", { FAIL_SHA256SUM: "1" }],
+  ];
+  for (const [name, overrides] of scenarios) {
+    await t.test(name, (t) => {
+      const sandbox = createSandbox(t);
+      const result = sandbox.run("publish-immutable", overrides);
+      assert.notEqual(result.status, 0, diagnostic(result));
+      assert.equal(createLines(sandbox.log()).length, 0, sandbox.log());
+    });
+  }
+});
+
+test("moving phase freshly preflights remote channels then publishes browser before main", (t) => {
+  const sandbox = createSandbox(t);
+  const immutable = sandbox.run("publish-immutable");
+  assert.equal(immutable.status, 0, diagnostic(immutable));
+  sandbox.appendLog("===ADVANCE===\n");
+
+  const moving = sandbox.run("advance-moving", {
+    BROWSER_DIGEST: digests.browser,
+    MAIN_DIGEST: digests.main,
+  });
+  assert.equal(moving.status, 0, diagnostic(moving));
+  const movingLog = sandbox.log().split("===ADVANCE===\n")[1];
+  const firstCreate = movingLog.indexOf("create|");
+  for (const ref of [
+    "ghcr.io/example/ocg-manager:1.8",
+    "ghcr.io/example/ocg-manager-browser:1.8",
+    "ghcr.io/example/ocg-manager:latest",
+    "ghcr.io/example/ocg-manager-browser:latest",
+  ]) {
+    const inspect = movingLog.indexOf(`inspect|buildx imagetools inspect ${ref}`);
+    assert.ok(inspect >= 0 && inspect < firstCreate, `${ref} was not freshly preflighted\n${movingLog}`);
+  }
+  assert.deepEqual(
+    createLines(movingLog).map((line) => /--tag ([^ ]+)/.exec(line)?.[1]),
+    [
+      "ghcr.io/example/ocg-manager-browser:1.8",
+      "ghcr.io/example/ocg-manager:1.8",
+      "ghcr.io/example/ocg-manager-browser:latest",
+      "ghcr.io/example/ocg-manager:latest",
+    ],
+  );
+});

--- a/scripts/generate-updater-manifest.test.mjs
+++ b/scripts/generate-updater-manifest.test.mjs
@@ -237,6 +237,10 @@ test("release workflow keeps reusable quality checks out of the native build mat
     new URL("../.github/workflows/container.yml", import.meta.url),
     "utf8",
   );
+  const containerPublishHelper = readFileSync(
+    new URL("./container-publish.sh", import.meta.url),
+    "utf8",
+  );
 
   assert.match(quality, /\n  pull_request:/);
   assert.match(quality, /\n  web:/);
@@ -294,7 +298,8 @@ test("release workflow keeps reusable quality checks out of the native build mat
   assert.match(bake, /group "smoke"/);
   assert.match(bake, /target "manager-smoke"/);
   assert.match(bake, /target "browser-smoke"/);
-  assert.match(containerWorkflow, /release-policy\.mjs immutable-tag/);
+  assert.match(containerWorkflow, /bash scripts\/container-publish\.sh publish-immutable/);
+  assert.match(containerPublishHelper, /release-policy\.mjs immutable-tag/);
   assert.match(containerWorkflow, /group: ghcr-moving-channels\s+queue: max/);
 });
 

--- a/scripts/release-policy.test.mjs
+++ b/scripts/release-policy.test.mjs
@@ -170,6 +170,10 @@ test("container publication checks out the release tag or an explicit source ref
     workflow,
     /ref: \$\{\{ inputs\.source_ref != '' && inputs\.source_ref \|\| format\('refs\/tags\/\{0\}', steps\.release\.outputs\.tag\) \}\}/,
   );
+  assert.match(
+    workflow,
+    /ref: \$\{\{ inputs\.source_ref != '' && inputs\.source_ref \|\| format\('refs\/tags\/\{0\}', needs\.resolve\.outputs\.tag\) \}\}/,
+  );
   assert.match(workflow, /git show-ref --verify --quiet "\$expected_ref"/);
   assert.match(workflow, /tag_commit=\$\(git rev-parse "\$expected_ref\^\{commit\}"\)/);
   assert.match(workflow, /node scripts\/release\.mjs --check/);
@@ -177,7 +181,55 @@ test("container publication checks out the release tag or an explicit source ref
   assert.match(workflow, /file: \.\/Dockerfile\.browser/);
   assert.match(workflow, /Smoke-test browser container and real Chromium/);
   assert.match(workflow, /provenance: mode=max[\s\S]*?sbom: true/);
-  assert.match(workflow, /subject-name: \$\{\{ needs\.build\.outputs\.browser_image \}\}/);
+  assert.match(workflow, /subject-name: \$\{\{ needs\.resolve\.outputs\.browser_image \}\}/);
+  assert.match(workflow, /subject-name: \$\{\{ needs\.resolve\.outputs\.image \}\}/);
+  assert.match(workflow, /subject-digest: \$\{\{ steps\.publish_tags\.outputs\.main_digest \}\}/);
+  assert.match(workflow, /subject-digest: \$\{\{ steps\.publish_tags\.outputs\.browser_digest \}\}/);
+});
+
+test("container publication builds each architecture natively and merges both digests", () => {
+  const workflow = readFileSync(
+    new URL("../.github/workflows/container.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(workflow, /arch: \[amd64, arm64\]/);
+  assert.match(workflow, /- arch: amd64\n\s+runs-on: ubuntu-24\.04\n/);
+  assert.match(workflow, /- arch: arm64\n\s+runs-on: ubuntu-24\.04-arm\n/);
+  assert.match(workflow, /runs-on: \$\{\{ matrix\.runs-on \}\}/);
+  assert.match(workflow, /timeout-minutes: 120/);
+  // Without parameterized platforms the arm64 leg would bake amd64 images through QEMU.
+  assert.match(workflow, /platforms: linux\/\$\{\{ matrix\.arch \}\}/);
+  assert.doesNotMatch(workflow, /platforms: linux\/amd64\b/);
+
+  assert.match(workflow, /browser_digest_amd64: \$\{\{ steps\.record_amd64\.outputs\.browser_digest \}\}/);
+  assert.match(workflow, /browser_digest_arm64: \$\{\{ steps\.record_arm64\.outputs\.browser_digest \}\}/);
+  assert.match(workflow, /digest_amd64: \$\{\{ steps\.record_amd64\.outputs\.digest \}\}/);
+  assert.match(workflow, /digest_arm64: \$\{\{ steps\.record_arm64\.outputs\.digest \}\}/);
+  assert.match(workflow, /MAIN_DIGEST_AMD64: \$\{\{ needs\.build\.outputs\.digest_amd64 \}\}/);
+  assert.match(workflow, /MAIN_DIGEST_ARM64: \$\{\{ needs\.build\.outputs\.digest_arm64 \}\}/);
+  assert.match(workflow, /BROWSER_DIGEST_AMD64: \$\{\{ needs\.build\.outputs\.browser_digest_amd64 \}\}/);
+  assert.match(workflow, /BROWSER_DIGEST_ARM64: \$\{\{ needs\.build\.outputs\.browser_digest_arm64 \}\}/);
+  assert.match(workflow, /if: matrix\.arch == 'amd64'/);
+  assert.match(workflow, /if: matrix\.arch == 'arm64'/);
+  assert.match(workflow, /cache-from: type=gha,scope=ocg-manager-linux-\$\{\{ matrix\.arch \}\}/);
+  assert.match(workflow, /cache-to: type=gha,mode=max,scope=ocg-manager-linux-\$\{\{ matrix\.arch \}\}/);
+  assert.match(workflow, /cache-from: type=gha,scope=ocg-browser-linux-\$\{\{ matrix\.arch \}\}/);
+  assert.match(workflow, /cache-to: type=gha,mode=max,scope=ocg-browser-linux-\$\{\{ matrix\.arch \}\}/);
+  assert.match(workflow, /CACHE_SCOPE=ocg-manager-linux-\$\{\{ matrix\.arch \}\}/);
+  assert.match(workflow, /CACHE_BROWSER_SCOPE=ocg-browser-linux-\$\{\{ matrix\.arch \}\}/);
+  assert.match(workflow, /SMOKE_IMAGE: ocg-manager:smoke-\$\{\{ github\.run_id \}\}-\$\{\{ matrix\.arch \}\}/);
+
+  const bake = readFileSync(
+    new URL("../docker-bake.hcl", import.meta.url),
+    "utf8",
+  );
+  assert.match(bake, /variable "CACHE_SCOPE" \{\s*\n\s*default = "ocg-manager-linux-amd64"/);
+  assert.match(bake, /variable "CACHE_BROWSER_SCOPE" \{\s*\n\s*default = "ocg-browser-linux-amd64"/);
+  assert.match(bake, /cache-from = \["type=gha,scope=\$\{CACHE_SCOPE\}"\]/);
+  assert.match(bake, /cache-from = \["type=gha,scope=\$\{CACHE_BROWSER_SCOPE\}"\]/);
+  // A platforms pin in the bake smoke targets would bake the wrong architecture
+  // on the arm64 leg; the native runner default is required.
+  assert.doesNotMatch(bake, /platforms\s*=/);
 });
 
 test("paired moving channels either converge at the candidate or remain aligned", () => {
@@ -211,25 +263,68 @@ test("container publication preflights paired moving channels before publishing 
   const publishStep = workflow.match(
     /- name: Publish tags without moving immutable references or rolling channels back[\s\S]*?(?=\n      - name: Generate signed GitHub provenance)/,
   )?.[0] ?? "";
+  const deriveBrowser = publishStep.indexOf('derive_candidate_index "$BROWSER_IMAGE"');
+  const deriveMain = publishStep.indexOf('derive_candidate_index "$MAIN_IMAGE"');
   const mainPreflight = publishStep.indexOf('preflight_immutable_image_tags "$MAIN_IMAGE" "$MAIN_DIGEST"');
   const browserPreflight = publishStep.indexOf('preflight_immutable_image_tags "$BROWSER_IMAGE" "$BROWSER_DIGEST"');
   const movingPreflight = publishStep.indexOf('preflight_moving_pair "$MINOR_CHANNEL"');
   const browserPublish = publishStep.indexOf('publish_immutable_image_tags "$BROWSER_IMAGE" "$BROWSER_DIGEST"');
   const mainPublish = publishStep.indexOf('publish_immutable_image_tags "$MAIN_IMAGE" "$MAIN_DIGEST"');
   const pairVerification = publishStep.indexOf('verify_paired_tag "$CANDIDATE_VERSION"');
+  const movingPublish = publishStep.indexOf('publish_moving_pair "$MINOR_CHANNEL"');
 
+  assert.ok(publishStep.match(/MAIN_DIGEST_AMD64 MAIN_DIGEST_ARM64 BROWSER_DIGEST_AMD64 BROWSER_DIGEST_ARM64/),
+    "all four architecture digests must be asserted non-empty before any publication");
+  assert.match(publishStep, /\[\[ -z "\$\{!arch_digest_var\}" \]\]/,
+    "the non-empty assertion must fail the step, not just enumerate the variables");
+  assert.ok(deriveBrowser >= 0 && deriveMain >= 0,
+    "both images must derive a merged multi-architecture index digest");
+  assert.ok(deriveBrowser < deriveMain,
+    "derive and publish the browser sidecar digest before the main image");
   assert.ok(mainPreflight >= 0 && browserPreflight >= 0, "both images must be preflighted");
   assert.ok(movingPreflight >= 0, "moving channels must be preflighted as a pair");
+  assert.ok(movingPreflight < deriveBrowser,
+    "paired moving-channel decisions need no candidate digest and must precede the first registry write");
   assert.ok(mainPreflight < browserPublish && browserPreflight < browserPublish,
-    "all immutable and moving-tag decisions must finish before the first tag write");
+    "all sha- tag decisions must finish before the first sha- tag write");
+  assert.ok(movingPreflight < movingPublish,
+    "moving-channel decisions must finish before the first moving-channel write");
   assert.ok(browserPublish < mainPublish,
     "publish the browser sidecar before exposing the matching main image");
   assert.ok(mainPublish < pairVerification,
     "verify both images together only after their publication sequence completes");
   assert.match(publishStep, /paired-channel/);
   assert.match(publishStep, /MOVING_EXPECTED_VERSIONS\["\$tag"\]=\$version/);
+  assert.match(
+    publishStep,
+    /EXPECTED_DIGESTS\["\$main_ref"\]=\$\(\[\[ "\$\{MOVING_DECISIONS\["\$main_ref"\]\}" == true \]\] && printf '%s' "\$MAIN_DIGEST" \|\| printf '%s' "\$\{MOVING_EXISTING_DIGESTS\["\$main_ref"\]\}"\)/,
+    "the main expected-digest expansion must stay a plain parameter expansion (stray characters corrupt kept digests)",
+  );
+  assert.match(
+    publishStep,
+    /EXPECTED_DIGESTS\["\$browser_ref"\]=\$\(\[\[ "\$\{MOVING_DECISIONS\["\$browser_ref"\]\}" == true \]\] && printf '%s' "\$BROWSER_DIGEST" \|\| printf '%s' "\$\{MOVING_EXISTING_DIGESTS\["\$browser_ref"\]\}"\)/,
+    "the browser expected-digest expansion must stay a plain parameter expansion (stray characters corrupt kept digests)",
+  );
+  assert.match(publishStep, /verify_merged_index "\$image" "\$ref" \|\| return 1/,
+    "derive_candidate_index must propagate verify_merged_index failures explicitly; errexit does not reach command substitutions");
   assert.match(publishStep, /verify_paired_moving_tag/);
   assert.match(publishStep, /verify_published_digest "\$BROWSER_IMAGE:\$tag"/);
+  assert.match(
+    publishStep,
+    /docker buildx imagetools create[\s\S]*?--annotation "index:org\.opencontainers\.image\.version=\$CANDIDATE_VERSION"[\s\S]*?--annotation "index:org\.opencontainers\.image\.revision=\$FULL_SHA"[\s\S]*?"\$image@\$amd64_digest" "\$image@\$arm64_digest"/,
+    "every tag must be assembled from both architecture digests with explicit index annotations",
+  );
+  assert.match(publishStep, /application\/vnd\.oci\.image\.index\.v1\+json/,
+    "published indexes must be verified as OCI image indexes");
+  assert.match(workflow, /oci-mediatypes=true/,
+    "build-push must lock in OCI media types so index annotations cannot be dropped");
+  assert.match(publishStep, /'\.annotations\."org\.opencontainers\.image\.revision" \/\/ empty'/,
+    "verify_merged_index must check the revision annotation as well as the version");
+  assert.match(publishStep, /inspect_version/);
+  assert.match(workflow, /'\.annotations\."org\.opencontainers\.image\.version" \/\/ empty'/,
+    "inspect_version must prefer the index annotation");
+  assert.match(workflow, /\.platform\.architecture == "arm64"/,
+    "inspect_version must fall back to arm64 children after amd64");
 });
 
 test("container publication requires anonymous exact-version pulls", () => {
@@ -244,6 +339,10 @@ test("container publication requires anonymous exact-version pulls", () => {
   assert.match(anonymousPull, /export DOCKER_CONFIG="\$anonymous_docker_config"/);
   assert.match(anonymousPull, /docker pull --quiet "\$MAIN_IMAGE:\$CANDIDATE_VERSION"/);
   assert.match(anonymousPull, /docker pull --quiet "\$BROWSER_IMAGE:\$CANDIDATE_VERSION"/);
+  assert.match(anonymousPull, /verify_public_index "\$MAIN_IMAGE:\$CANDIDATE_VERSION"/);
+  assert.match(anonymousPull, /verify_public_index "\$BROWSER_IMAGE:\$CANDIDATE_VERSION"/);
+  assert.match(anonymousPull, /"amd64,arm64"/,
+    "anonymous pulls must expose both architectures in the public manifest");
 });
 
 test("release preflight rejects a tag that does not match repository versions", () => {

--- a/scripts/release-policy.test.mjs
+++ b/scripts/release-policy.test.mjs
@@ -161,30 +161,43 @@ test("the exact draft Release identity flows through verification and publicatio
   assert.doesNotMatch(publishJob, /releases\/tags\//);
 });
 
-test("container publication checks out the release tag or an explicit source ref", () => {
+test("resolve is the only phase that interprets a mutable container source ref", () => {
   const workflow = readFileSync(
     new URL("../.github/workflows/container.yml", import.meta.url),
     "utf8",
   );
+  const resolveJob = workflow.match(/\n  resolve:[\s\S]*?\n  build:/)?.[0] ?? "";
+  const buildJob = workflow.match(/\n  build:[\s\S]*?\n  publish:/)?.[0] ?? "";
+  const publishJob = workflow.match(/\n  publish:[\s\S]*$/)?.[0] ?? "";
+
   assert.match(
-    workflow,
+    resolveJob,
     /ref: \$\{\{ inputs\.source_ref != '' && inputs\.source_ref \|\| format\('refs\/tags\/\{0\}', steps\.release\.outputs\.tag\) \}\}/,
   );
-  assert.match(
-    workflow,
-    /ref: \$\{\{ inputs\.source_ref != '' && inputs\.source_ref \|\| format\('refs\/tags\/\{0\}', needs\.resolve\.outputs\.tag\) \}\}/,
-  );
-  assert.match(workflow, /git show-ref --verify --quiet "\$expected_ref"/);
-  assert.match(workflow, /tag_commit=\$\(git rev-parse "\$expected_ref\^\{commit\}"\)/);
-  assert.match(workflow, /node scripts\/release\.mjs --check/);
+  assert.match(resolveJob, /full_sha=\$\(git rev-parse HEAD\)/);
+  assert.match(resolveJob, /node scripts\/release\.mjs --check/);
+
+  assert.match(buildJob, /ref: \$\{\{ needs\.resolve\.outputs\.full_sha \}\}/);
+  assert.match(buildJob, /EXPECTED_SHA: \$\{\{ needs\.resolve\.outputs\.full_sha \}\}/);
+  assert.match(buildJob, /actual_sha=\$\(git rev-parse HEAD\)/);
+  assert.match(buildJob, /\[\[ "\$actual_sha" != "\$EXPECTED_SHA" \]\]/);
+  assert.doesNotMatch(buildJob, /inputs\.source_ref|refs\/tags|github\.workflow_sha/,
+    "both matrix legs must build the resolved commit without symbolic-ref reuse");
+
+  assert.match(publishJob, /ref: \$\{\{ github\.workflow_sha \}\}/);
+  assert.match(publishJob, /EXPECTED_WORKFLOW_SHA: \$\{\{ github\.workflow_sha \}\}/);
+  assert.match(publishJob, /\[\[ "\$actual_sha" != "\$EXPECTED_WORKFLOW_SHA" \]\]/);
+  assert.doesNotMatch(publishJob, /inputs\.source_ref|refs\/tags/,
+    "the privileged publish helper must come from the trusted workflow commit");
+
   assert.match(workflow, /docker-bake\.hcl/);
   assert.match(workflow, /file: \.\/Dockerfile\.browser/);
   assert.match(workflow, /Smoke-test browser container and real Chromium/);
   assert.match(workflow, /provenance: mode=max[\s\S]*?sbom: true/);
   assert.match(workflow, /subject-name: \$\{\{ needs\.resolve\.outputs\.browser_image \}\}/);
   assert.match(workflow, /subject-name: \$\{\{ needs\.resolve\.outputs\.image \}\}/);
-  assert.match(workflow, /subject-digest: \$\{\{ steps\.publish_tags\.outputs\.main_digest \}\}/);
-  assert.match(workflow, /subject-digest: \$\{\{ steps\.publish_tags\.outputs\.browser_digest \}\}/);
+  assert.match(workflow, /subject-digest: \$\{\{ steps\.immutable\.outputs\.main_digest \}\}/);
+  assert.match(workflow, /subject-digest: \$\{\{ steps\.immutable\.outputs\.browser_digest \}\}/);
 });
 
 test("container publication builds each architecture natively and merges both digests", () => {
@@ -255,76 +268,93 @@ test("paired moving channels either converge at the candidate or remain aligned"
   }), /Refusing to leave paired container channel split/);
 });
 
-test("container publication preflights paired moving channels before publishing the browser then main pair", () => {
+test("immutable publication, public proof, attestations, and moving channels are strictly ordered", () => {
   const workflow = readFileSync(
     new URL("../.github/workflows/container.yml", import.meta.url),
     "utf8",
   );
-  const publishStep = workflow.match(
-    /- name: Publish tags without moving immutable references or rolling channels back[\s\S]*?(?=\n      - name: Generate signed GitHub provenance)/,
-  )?.[0] ?? "";
-  const deriveBrowser = publishStep.indexOf('derive_candidate_index "$BROWSER_IMAGE"');
-  const deriveMain = publishStep.indexOf('derive_candidate_index "$MAIN_IMAGE"');
-  const mainPreflight = publishStep.indexOf('preflight_immutable_image_tags "$MAIN_IMAGE" "$MAIN_DIGEST"');
-  const browserPreflight = publishStep.indexOf('preflight_immutable_image_tags "$BROWSER_IMAGE" "$BROWSER_DIGEST"');
-  const movingPreflight = publishStep.indexOf('preflight_moving_pair "$MINOR_CHANNEL"');
-  const browserPublish = publishStep.indexOf('publish_immutable_image_tags "$BROWSER_IMAGE" "$BROWSER_DIGEST"');
-  const mainPublish = publishStep.indexOf('publish_immutable_image_tags "$MAIN_IMAGE" "$MAIN_DIGEST"');
-  const pairVerification = publishStep.indexOf('verify_paired_tag "$CANDIDATE_VERSION"');
-  const movingPublish = publishStep.indexOf('publish_moving_pair "$MINOR_CHANNEL"');
+  const immutable = workflow.indexOf("      - name: Publish and verify immutable version and commit tags");
+  const anonymous = workflow.indexOf("      - name: Verify public anonymous GHCR pulls");
+  const mainAttestation = workflow.indexOf("      - name: Generate signed GitHub provenance\n");
+  const browserAttestation = workflow.indexOf("      - name: Generate signed GitHub provenance for browser image");
+  const moving = workflow.indexOf("      - name: Re-read and advance paired moving channels");
 
-  assert.ok(publishStep.match(/MAIN_DIGEST_AMD64 MAIN_DIGEST_ARM64 BROWSER_DIGEST_AMD64 BROWSER_DIGEST_ARM64/),
-    "all four architecture digests must be asserted non-empty before any publication");
-  assert.match(publishStep, /\[\[ -z "\$\{!arch_digest_var\}" \]\]/,
-    "the non-empty assertion must fail the step, not just enumerate the variables");
-  assert.ok(deriveBrowser >= 0 && deriveMain >= 0,
-    "both images must derive a merged multi-architecture index digest");
-  assert.ok(deriveBrowser < deriveMain,
-    "derive and publish the browser sidecar digest before the main image");
-  assert.ok(mainPreflight >= 0 && browserPreflight >= 0, "both images must be preflighted");
-  assert.ok(movingPreflight >= 0, "moving channels must be preflighted as a pair");
-  assert.ok(movingPreflight < deriveBrowser,
-    "paired moving-channel decisions need no candidate digest and must precede the first registry write");
-  assert.ok(mainPreflight < browserPublish && browserPreflight < browserPublish,
-    "all sha- tag decisions must finish before the first sha- tag write");
-  assert.ok(movingPreflight < movingPublish,
-    "moving-channel decisions must finish before the first moving-channel write");
-  assert.ok(browserPublish < mainPublish,
-    "publish the browser sidecar before exposing the matching main image");
-  assert.ok(mainPublish < pairVerification,
-    "verify both images together only after their publication sequence completes");
-  assert.match(publishStep, /paired-channel/);
-  assert.match(publishStep, /MOVING_EXPECTED_VERSIONS\["\$tag"\]=\$version/);
-  assert.match(
-    publishStep,
-    /EXPECTED_DIGESTS\["\$main_ref"\]=\$\(\[\[ "\$\{MOVING_DECISIONS\["\$main_ref"\]\}" == true \]\] && printf '%s' "\$MAIN_DIGEST" \|\| printf '%s' "\$\{MOVING_EXISTING_DIGESTS\["\$main_ref"\]\}"\)/,
-    "the main expected-digest expansion must stay a plain parameter expansion (stray characters corrupt kept digests)",
+  assert.ok(
+    immutable >= 0
+      && immutable < anonymous
+      && anonymous < mainAttestation
+      && mainAttestation < browserAttestation
+      && browserAttestation < moving,
+    "moving channels must wait for immutable tags, anonymous pulls, and both attestations",
   );
-  assert.match(
-    publishStep,
-    /EXPECTED_DIGESTS\["\$browser_ref"\]=\$\(\[\[ "\$\{MOVING_DECISIONS\["\$browser_ref"\]\}" == true \]\] && printf '%s' "\$BROWSER_DIGEST" \|\| printf '%s' "\$\{MOVING_EXISTING_DIGESTS\["\$browser_ref"\]\}"\)/,
-    "the browser expected-digest expansion must stay a plain parameter expansion (stray characters corrupt kept digests)",
+  assert.match(workflow, /concurrency:\n\s+group: ghcr-moving-channels\n\s+queue: max/);
+  assert.match(workflow, /run: bash scripts\/container-publish\.sh publish-immutable/);
+  assert.match(workflow, /run: bash scripts\/container-publish\.sh advance-moving/);
+  assert.match(workflow, /subject-digest: \$\{\{ steps\.immutable\.outputs\.main_digest \}\}/);
+  assert.match(workflow, /subject-digest: \$\{\{ steps\.immutable\.outputs\.browser_digest \}\}/);
+});
+
+test("candidate index digests are computed without a registry tag before every immutable preflight", () => {
+  const helper = readFileSync(
+    new URL("./container-publish.sh", import.meta.url),
+    "utf8",
   );
-  assert.match(publishStep, /verify_merged_index "\$image" "\$ref" \|\| return 1/,
-    "derive_candidate_index must propagate verify_merged_index failures explicitly; errexit does not reach command substitutions");
-  assert.match(publishStep, /verify_paired_moving_tag/);
-  assert.match(publishStep, /verify_published_digest "\$BROWSER_IMAGE:\$tag"/);
+  const candidateStart = helper.indexOf("candidate_manifest_for() {");
+  const candidateEnd = helper.indexOf("verify_published_digest() {");
+  const candidateFunction = helper.slice(candidateStart, candidateEnd);
+  const immutableStart = helper.indexOf("publish_immutable_phase() {");
+  const movingStart = helper.indexOf("advance_moving_phase() {");
+  const immutablePhase = helper.slice(immutableStart, movingStart);
+  const localMainDigest = immutablePhase.indexOf('main_digest=$(manifest_digest "$main_manifest")');
+  const immutablePreflight = immutablePhase.indexOf('immutable_decisions["$key"]=$(check_immutable');
+  const firstTagWrite = immutablePhase.indexOf('publish_immutable_image_tags "$BROWSER_IMAGE"');
+
+  assert.match(candidateFunction, /docker buildx imagetools create[\s\S]*?--dry-run/);
+  assert.doesNotMatch(candidateFunction, /--tag|staging/);
+  assert.match(helper, /if ! checksum=\$\(printf '%s' "\$manifest" \| sha256sum\); then/);
+  assert.match(immutablePhase, /browser_manifest=\$\(candidate_manifest_for "\$BROWSER_IMAGE"\)/);
+  assert.match(immutablePhase, /main_manifest=\$\(candidate_manifest_for "\$MAIN_IMAGE"\)/);
+  assert.match(immutablePhase, /verify_index_json "\$BROWSER_IMAGE" "browser candidate dry-run" "\$browser_manifest"/);
+  assert.match(immutablePhase, /verify_index_json "\$MAIN_IMAGE" "main candidate dry-run" "\$main_manifest"/);
+  assert.ok(localMainDigest >= 0 && localMainDigest < immutablePreflight,
+    "both local candidate digests must exist before immutable preflight");
+  assert.ok(immutablePreflight >= 0 && immutablePreflight < firstTagWrite,
+    "all immutable decisions must finish before the first version or sha tag write");
   assert.match(
-    publishStep,
-    /docker buildx imagetools create[\s\S]*?--annotation "index:org\.opencontainers\.image\.version=\$CANDIDATE_VERSION"[\s\S]*?--annotation "index:org\.opencontainers\.image\.revision=\$FULL_SHA"[\s\S]*?"\$image@\$amd64_digest" "\$image@\$arm64_digest"/,
-    "every tag must be assembled from both architecture digests with explicit index annotations",
+    immutablePhase,
+    /for image_and_digest in[\s\S]*?"\$MAIN_IMAGE \$main_digest"[\s\S]*?"\$BROWSER_IMAGE \$browser_digest"[\s\S]*?for tag in "\$CANDIDATE_VERSION" "sha-\$SHORT_SHA"/,
   );
-  assert.match(publishStep, /application\/vnd\.oci\.image\.index\.v1\+json/,
-    "published indexes must be verified as OCI image indexes");
-  assert.match(workflow, /oci-mediatypes=true/,
-    "build-push must lock in OCI media types so index annotations cannot be dropped");
-  assert.match(publishStep, /'\.annotations\."org\.opencontainers\.image\.revision" \/\/ empty'/,
-    "verify_merged_index must check the revision annotation as well as the version");
-  assert.match(publishStep, /inspect_version/);
-  assert.match(workflow, /'\.annotations\."org\.opencontainers\.image\.version" \/\/ empty'/,
-    "inspect_version must prefer the index annotation");
-  assert.match(workflow, /\.platform\.architecture == "arm64"/,
-    "inspect_version must fall back to arm64 children after amd64");
+  assert.match(helper, /application\/vnd\.oci\.image\.index\.v1\+json/);
+  assert.match(helper, /org\.opencontainers\.image\.version/);
+  assert.match(helper, /org\.opencontainers\.image\.revision/);
+  assert.match(helper, /arch_manifests[\s\S]*?expected_manifests/);
+  assert.doesNotMatch(helper, /derive_candidate_index|staging[-_]/);
+});
+
+test("moving channels re-read remote state and publish browser before main", () => {
+  const helper = readFileSync(
+    new URL("./container-publish.sh", import.meta.url),
+    "utf8",
+  );
+  const movingStart = helper.indexOf("advance_moving_phase() {");
+  const movingPhase = helper.slice(movingStart);
+  const freshRead = movingPhase.indexOf(
+    'verify_remote_candidate_index "$BROWSER_IMAGE" "$BROWSER_IMAGE:$CANDIDATE_VERSION" "$BROWSER_DIGEST"',
+  );
+  const minorPreflight = movingPhase.indexOf('preflight_moving_pair "$MINOR_CHANNEL"');
+  const minorPublish = movingPhase.lastIndexOf('publish_moving_pair "$MINOR_CHANNEL"');
+  const browserPublish = movingPhase.indexOf('publish_moving "$BROWSER_IMAGE" "$tag" "$BROWSER_DIGEST"');
+  const mainPublish = movingPhase.indexOf('publish_moving "$MAIN_IMAGE" "$tag" "$MAIN_DIGEST"');
+
+  assert.ok(freshRead >= 0 && freshRead < minorPreflight,
+    "moving-channel phase must freshly verify the immutable candidate first");
+  assert.ok(minorPreflight >= 0 && minorPreflight < minorPublish,
+    "all moving-channel decisions must finish before the first moving write");
+  assert.ok(browserPublish >= 0 && browserPublish < mainPublish,
+    "the browser dependency must move before the matching main channel");
+  assert.match(movingPhase, /if \[\[ "\$PUBLISH_LATEST" == true \]\]; then\n\s+preflight_moving_pair latest/);
+  assert.match(movingPhase, /decision=\$\(node scripts\/release-policy\.mjs paired-channel/);
+  assert.match(movingPhase, /verify_paired_moving_tag "\$tag"/);
 });
 
 test("container publication requires anonymous exact-version pulls", () => {


### PR DESCRIPTION
## Summary

Adds native `linux/arm64` to the container release channel by converting `container.yml` to a per-architecture build matrix, merging both architectures into one OCI index per tag. Zero changes to `Dockerfile` / `Dockerfile.browser` / `release-policy.mjs`; desktop installers remain amd64/x64-only.

- **Build**: new `resolve` job produces release metadata (tag/version/minor/stable/publish_latest, contents:read); build job runs a matrix — amd64 on `ubuntu-24.04`, arm64 on `ubuntu-24.04-arm` (native runners, no QEMU for release artifacts). Each leg runs the full existing smoke suite (manager health/dashboard/auth; browser sidecar real-Chromium verification) natively, uses per-architecture GHA cache scopes (`*-amd64` strings unchanged so existing cache keeps hitting), arch-suffixed smoke resource names, and records only its own `digest_<arch>` / `browser_digest_<arch>` outputs. Build-push `platforms` is parameterized to `linux/${{ matrix.arch }}` and `docker-bake.hcl` smoke targets drop their hardcoded `platforms` pin — without that, the arm64 leg would bake amd64 images via QEMU.
- **Publish**: asserts all four architecture digests are non-empty, then derives the candidate index digest by two-source `imagetools create` on the version tag (sidecar first) with explicit `index:org.opencontainers.image.version/revision` annotations (multi-source create does not inherit source annotations). Every created tag is verified as an OCI image index with exactly the candidate child manifests, the version annotation, and the revision annotation. Paired moving-channel decisions run **before** the first registry write (they need no candidate digest); immutability refusals (including legacy single-platform tags and nondeterministic rebuilds) fail fast instead of overwriting. Anonymous-pull gate now asserts both architectures are present. Attestation subjects use the merged index digests.
- **Tests**: `scripts/release-policy.test.mjs` updated/extended — pins matrix wiring, `platforms: linux/${{ matrix.arch }}` (anti-QEMU regression), four digest outputs, two-source create with annotations, OCI mediaType check, annotation-first `inspect_version` with arm64 fallback, decision-before-write ordering, and the exact expected-digest expansions (a stray-character bug class caught during review).
- **Docs**: USER (en/zh), README, `compose.example.yaml` (drops both `platform:` pins, adds a legacy-Compose note), AGENTS.md, MAINTAINER (en/zh) — container images are amd64+arm64; desktop "no ARM64" wording kept but scoped to installers.

(Replaces #45, which inadvertently included local planning artifacts; this branch is the same change with a clean single commit.)

## Verification

- `node --test scripts/release-policy.test.mjs` 12/12; `node scripts/release.mjs --check` passes; all workflow `run:` blocks pass `bash -n`; YAML validated structurally (matrix/outputs/needs/permissions).
- Quality gate green on this branch on the fork, and green on #45's identical code: https://github.com/eveloki/opencode-go-mgr/actions/runs/32278008707 and https://github.com/klarkxy/opencode-go-mgr/actions/runs/32281423100 (the fork's first Rust attempt hit the 30-min job timeout on a hung `apt-get install`, unrelated to the change; rerun green).
- Three rounds of adversarial review; two blocking findings (stray `]` corrupting kept browser channel digests; errexit being swallowed in command substitution inside `derive_candidate_index`) were fixed and pinned with tests.

## Before the first stable dual-arch release

The first real publication must go through the `workflow_dispatch` rehearsal with a temporary non-stable tag: full pipeline on a temp tag, `docker pull` architecture checks on both amd64 and arm64 hosts, confirm minor/latest untouched, then delete the rehearsal tags.