### PR TITLE
fix(pricing): DeepSeek peak is Monday to Friday, so weekends bill off-peak

### DIFF
--- a/crates/ocg-core/src/pricing.rs
+++ b/crates/ocg-core/src/pricing.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result, anyhow, bail};
-use chrono::{DateTime, Timelike, Utc};
+use chrono::{DateTime, Datelike, Timelike, Utc};
 use futures_util::StreamExt;
 use reqwest::redirect::{Attempt, Policy};
 use serde::{Deserialize, Serialize};
@@ -902,7 +902,16 @@ fn select_priced_model<'a>(
 }
 
 fn is_official_peak_utc(at: DateTime<Utc>) -> bool {
-    // Official Go docs: DeepSeek Peak hours are 01:00-04:00 and 06:00-10:00 UTC.
+    // Official Go docs: DeepSeek Peak hours are 01:00-04:00 and 06:00-10:00 UTC,
+    // Monday through Friday. Saturday and Sunday are off-peak all day.
+    //
+    // The weekday is read in UTC rather than on DeepSeek's Beijing clock. That is
+    // sound only because both windows end at 10:00 UTC, well before 16:00 UTC --
+    // the instant a UTC date and a Beijing date begin to disagree. If a window
+    // ever extends past 16:00 UTC this needs to move to Asia/Shanghai.
+    if at.weekday().number_from_monday() > 5 {
+        return false;
+    }
     let minutes = at.hour() * 60 + at.minute();
     (60..240).contains(&minutes) || (360..600).contains(&minutes)
 }
@@ -1530,10 +1539,15 @@ mod tests {
     #[test]
     fn deepseek_uses_utc_peak_and_off_peak_rows() {
         let snapshot = embedded_seed();
-        let off_peak = DateTime::parse_from_rfc3339("2026-08-16T12:00:00Z")
+        // Both instants are on Monday 2026-08-17. They used to sit on Sunday
+        // 2026-08-16, which made the `peak` half assert the weekend bug: a
+        // Sunday 07:00Z session is off-peak, so it cannot cost 1.76. Keeping
+        // this pair on a weekday leaves it testing the hour axis only; the
+        // weekday axis is covered by the test below.
+        let off_peak = DateTime::parse_from_rfc3339("2026-08-17T12:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        let peak = DateTime::parse_from_rfc3339("2026-08-16T07:00:00Z")
+        let peak = DateTime::parse_from_rfc3339("2026-08-17T07:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
         let off = snapshot
@@ -1546,6 +1560,47 @@ mod tests {
             .unwrap();
         assert!((off - 0.88).abs() < 1e-12);
         assert!((on - 1.76).abs() < 1e-12);
+    }
+
+    #[test]
+    fn deepseek_weekend_is_off_peak_at_every_hour() {
+        // Peak is Monday through Friday only, so both weekend days must price
+        // at the Off-Peak rows even inside the 01:00-04:00 / 06:00-10:00 windows.
+        let snapshot = embedded_seed();
+        for at in [
+            "2026-08-15T02:00:00Z", // Saturday, inside the first peak window
+            "2026-08-15T07:00:00Z", // Saturday, inside the second
+            "2026-08-16T02:00:00Z", // Sunday, inside the first
+            "2026-08-16T07:00:00Z", // Sunday, inside the second
+        ] {
+            let when = DateTime::parse_from_rfc3339(at)
+                .unwrap()
+                .with_timezone(&Utc);
+            let cost = snapshot
+                .estimate_at("deepseek-v4-flash", 1_000_000, 0, 0, 0, None, when)
+                .cost
+                .unwrap();
+            assert!(
+                (cost - 0.88).abs() < 1e-12,
+                "{at} is on a weekend and must bill off-peak (0.88), got {cost}"
+            );
+        }
+
+        // The Friday and Monday either side of that weekend still bill at peak,
+        // so this is a weekday boundary and not a blanket disable.
+        for at in ["2026-08-14T07:00:00Z", "2026-08-17T07:00:00Z"] {
+            let when = DateTime::parse_from_rfc3339(at)
+                .unwrap()
+                .with_timezone(&Utc);
+            let cost = snapshot
+                .estimate_at("deepseek-v4-flash", 1_000_000, 0, 0, 0, None, when)
+                .cost
+                .unwrap();
+            assert!(
+                (cost - 1.76).abs() < 1e-12,
+                "{at} is a weekday peak hour and must bill 1.76, got {cost}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #49. You said it might be a lot of work — it turned out to be four lines plus a test, so here it is ready to merge.

## The change

`is_official_peak_utc()` read only the minute of the UTC day. Peak is **Monday through Friday**, so the 14 weekend hours that fall inside `01:00-04:00` / `06:00-10:00` picked the `Peak` rows: `DeepSeek V4 Flash (Peak)` instead of `(Off-Peak)`, which is exactly **2×** on every column.

```rust
if at.weekday().number_from_monday() > 5 {
    return false;
}
```

`chrono` was already a dependency; this only adds `Datelike` to the existing `use`.

## The test was asserting the bug

This is the part worth a look. `deepseek_uses_utc_peak_and_off_peak_rows` pinned both instants to `2026-08-16`, which is a **Sunday**:

```rust
let peak = DateTime::parse_from_rfc3339("2026-08-16T07:00:00Z")...
assert!((on - 1.76).abs() < 1e-12);
```

A Sunday 07:00Z session cannot cost 1.76, so that half of the test was pinning the wrong behaviour in place. I moved the pair to Monday `2026-08-17` at the same two hours, which leaves it testing the hour axis alone, and added `deepseek_weekend_is_off_peak_at_every_hour` for the weekday axis. The new test checks all four weekend peak-hour instants bill 0.88, and — the load-bearing half — that the Friday and Monday either side still bill 1.76, so it fails on a blanket disable just as loudly as on the original bug.

## Why UTC and not Asia/Shanghai

Reading the weekday in UTC is correct **today** and I left a comment saying why: both windows end at 10:00 UTC, and a UTC date only starts disagreeing with a Beijing date at 16:00 UTC. So no instant inside either window can land on a different weekday under the two readings, and no test written against the published windows can separate them. The comment flags that this stops holding if a window ever moves past 16:00 UTC. Happy to switch it to a real `Asia/Shanghai` conversion if you'd rather not carry that assumption — it'd mean pulling in `chrono-tz` or hardcoding `FixedOffset::east(8*3600)`, which is why I didn't do it unasked.

## Verification

```
cargo test -p ocg-core --lib     424 passed; 0 failed; 1 ignored
cargo fmt --check -p ocg-core    clean
cargo clippy -p ocg-core --lib --all-targets    no new warnings
```

Reverting only the four-line guard and keeping the tests gives:

```
deepseek_weekend_is_off_peak_at_every_hour ... FAILED
  2026-08-15T02:00:00Z is on a weekend and must bill off-peak (0.88), got 1.76
```

so the test does fail without the fix. `cargo test` across the whole workspace doesn't run here — `glib-sys` wants GTK dev headers I don't have — so `ocg-core` is the only crate I exercised. It's also the only crate this touches.

Source for the rule, both languages: <https://api-docs.deepseek.com/quick_start/pricing> — *"01:00 - 04:00 and 06:00 - 10:00 UTC, Monday through Friday (all other hours are off-peak)"* / 「高峰时段为北京时间**周一至周五** 9:00 - 12:00、14:00 - 18:00」.
